### PR TITLE
Refactor: Immutable Image Tags

### DIFF
--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -17,6 +17,8 @@ steps:
       - 'github_owner=$_GITHUB_OWNER'
       - '-var'
       - 'github_repo=$_GITHUB_REPO'
+      - '-var'
+      - 'image_tag=$COMMIT_SHA'
     dir: 'terraform'
     id: 'tf-plan'
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -15,8 +15,6 @@ steps:
       - 'build'
       - '-t'
       - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_SERVICE_NAME/$_SERVICE_NAME:$COMMIT_SHA'
-      - '-t'
-      - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_SERVICE_NAME/$_SERVICE_NAME:latest'
       - 'app/'
     id: 'build-image'
 
@@ -24,8 +22,7 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     args: 
       - 'push'
-      - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_SERVICE_NAME/$_SERVICE_NAME'
-      - '--all-tags'
+      - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_SERVICE_NAME/$_SERVICE_NAME:$COMMIT_SHA'
     id: 'push-image'
 
   # 4. Terraform Init
@@ -62,6 +59,8 @@ steps:
       - 'github_owner=$_GITHUB_OWNER'
       - '-var'
       - 'github_repo=$_GITHUB_REPO'
+      - '-var'
+      - 'image_tag=$COMMIT_SHA'
     dir: 'terraform'
     id: 'tf-apply'
     env:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -49,7 +49,7 @@ resource "google_cloud_run_service" "default" {
   template {
     spec {
       containers {
-        image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.repo.repository_id}/${var.service_name}:latest"
+        image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.repo.repository_id}/${var.service_name}:${var.image_tag}"
       }
     }
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,7 +20,13 @@ variable "github_owner" {
   type        = string
 }
 
+
 variable "github_repo" {
   description = "GitHub repository name"
+  type        = string
+}
+
+variable "image_tag" {
+  description = "The tag of the container image to deploy"
   type        = string
 }


### PR DESCRIPTION
Refactors Cloud Run deployment to use immutable git commit SHA tags instead of 'latest', ensuring deterministic deployments.