### PR TITLE
feat: add cloud run domain mapping

### DIFF
--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -3,3 +3,4 @@ service_name = "calendarsync-dev"
 image_tag    = "latest" # or a specific dev tag
 github_owner = "billnapier"
 github_repo  = "calendarsync"
+domain_name  = "calendarsync-dev.billnapier.com"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -109,6 +109,20 @@ resource "google_cloud_run_service" "default" {
   depends_on = [google_project_service.run_api]
 }
 
+# Domain Mapping
+resource "google_cloud_run_domain_mapping" "default" {
+  location = var.region
+  name     = var.domain_name
+
+  metadata {
+    namespace = var.project_id
+  }
+
+  spec {
+    route_name = google_cloud_run_service.default.name
+  }
+}
+
 # Allow unauthenticated invocations (public access)
 data "google_iam_policy" "noauth" {
   binding {
@@ -202,7 +216,8 @@ locals {
     "127.0.0.1",
     "${var.project_id}.firebaseapp.com",
     "${var.project_id}.web.app",
-    replace(google_cloud_run_service.default.status[0].url, "https://", "")
+    replace(google_cloud_run_service.default.status[0].url, "https://", ""),
+    var.domain_name
   ]
 }
 
@@ -230,4 +245,8 @@ output "firebase_config" {
     appId             = google_firebase_web_app.default.app_id
   }
   sensitive = true
+}
+
+output "dns_records" {
+  value = google_cloud_run_domain_mapping.default.status
 }

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,3 +1,4 @@
 project_id   = "calendarsync-napier"
 github_owner = "billnapier"
 github_repo  = "calendarsync"
+domain_name  = "calendarsync.billnapier.com"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -30,3 +30,8 @@ variable "image_tag" {
   description = "The tag of the container image to deploy"
   type        = string
 }
+
+variable "domain_name" {
+  description = "Custom domain name for the Cloud Run service"
+  type        = string
+}


### PR DESCRIPTION
This PR adds custom domain mapping for Cloud Run services in dev and prod environments. \n\n## Changes\n- Added domain mapping resource to Cloud Run.\n- Added DNS record output.\n- Configured domain names for dev and prod.