### PR TITLE
fix: add ProxyFix for Cloud Run OAuth HTTPS

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -25,7 +25,7 @@ if not firebase_admin._apps: # pylint: disable=protected-access
 
 app = Flask(__name__)
 # Fix for Cloud Run (HTTPS behind proxy)
-app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
+app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_port=1)
 
 logging.basicConfig(level=logging.INFO)
 

--- a/app/app.py
+++ b/app/app.py
@@ -6,6 +6,7 @@ import os
 import logging
 # Third-party libraries
 from flask import Flask, render_template, request, session, redirect, url_for
+from werkzeug.middleware.proxy_fix import ProxyFix
 import firebase_admin
 from firebase_admin import firestore
 import google_auth_oauthlib.flow
@@ -23,6 +24,9 @@ if not firebase_admin._apps: # pylint: disable=protected-access
         firebase_admin.initialize_app()
 
 app = Flask(__name__)
+# Fix for Cloud Run (HTTPS behind proxy)
+app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
+
 logging.basicConfig(level=logging.INFO)
 
 # Configuration


### PR DESCRIPTION
Adds Werkzeug ProxyFix middleware to Flask app to correctly handle X-Forwarded-Proto headers from Cloud Run, resolving the 'insecure_transport' OAuth error.