### PR TITLE
feat: Select destination calendar from list

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -216,6 +216,7 @@ def oauth2callback():
 def fetch_user_calendars(user_uid):
     """Fetch user's Google Calendars using stored refresh token."""
     calendars = []
+    print(f"DEBUG: Starting fetch_user_calendars for {user_uid}")
     try:
         db = firestore.client()
         user_ref = db.collection('users').document(user_uid)
@@ -226,7 +227,7 @@ def fetch_user_calendars(user_uid):
             refresh_token = user_data.get('refresh_token')
             
             if refresh_token:
-                app.logger.info("Found refresh token for user %s, fetching calendars...", user_uid)
+                print(f"DEBUG: Found refresh token for {user_uid}, building credentials...")
                 client_config = get_client_config()
                 creds = Credentials(
                     None, # No access token initially
@@ -237,11 +238,12 @@ def fetch_user_calendars(user_uid):
                     scopes=SCOPES
                 )
                 
+                print("DEBUG: Calling Google Calendar API...")
                 service = build('calendar', 'v3', credentials=creds)
                 calendar_list = service.calendarList().list().execute()
                 
                 items = calendar_list.get('items', [])
-                app.logger.info("Calendar API response items count: %d", len(items))
+                print(f"DEBUG: Calendar API response items count: {len(items)}")
                 
                 for cal in items:
                     calendars.append({
@@ -249,11 +251,12 @@ def fetch_user_calendars(user_uid):
                         'summary': cal.get('summary', cal['id'])
                     })
             else:
-                app.logger.warning("No refresh token found for user %s", user_uid)
+                print(f"DEBUG: No refresh token found for user {user_uid}")
         else:
-             app.logger.warning("User document not found for %s", user_uid)
+             print(f"DEBUG: User document not found for {user_uid}")
                     
     except Exception as e: # pylint: disable=broad-exception-caught
+        print(f"DEBUG: Error fetching calendars: {e}")
         app.logger.error("Error fetching calendars: %s", e)
     
     return calendars

--- a/app/app.py
+++ b/app/app.py
@@ -248,6 +248,9 @@ def fetch_user_calendars(user_uid):
     except Exception as e: # pylint: disable=broad-exception-caught
         app.logger.error("Error fetching calendars: %s", e)
     
+    # Sort calendars alphabetically by summary
+    calendars.sort(key=lambda x: x['summary'].lower())
+    
     return calendars
 
 @app.route('/create_sync', methods=['GET', 'POST'])

--- a/app/app.py
+++ b/app/app.py
@@ -13,6 +13,8 @@ import google_auth_oauthlib.flow
 from google.cloud import secretmanager
 import google.auth.transport.requests
 from google.oauth2 import id_token
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
 
 
 # Initialize Firebase Admin SDK
@@ -211,6 +213,43 @@ def oauth2callback():
         app.logger.error("OAuth callback error: %s", e)
         return f"Authentication failed: {e}", 400
 
+def fetch_user_calendars(user_uid):
+    """Fetch user's Google Calendars using stored refresh token."""
+    calendars = []
+    try:
+        db = firestore.client()
+        user_ref = db.collection('users').document(user_uid)
+        user_doc = user_ref.get()
+        
+        if user_doc.exists:
+            user_data = user_doc.to_dict()
+            refresh_token = user_data.get('refresh_token')
+            
+            if refresh_token:
+                client_config = get_client_config()
+                creds = Credentials(
+                    None, # No access token initially
+                    refresh_token=refresh_token,
+                    token_uri=client_config['web']['token_uri'],
+                    client_id=client_config['web']['client_id'],
+                    client_secret=client_config['web']['client_secret'],
+                    scopes=SCOPES
+                )
+                
+                service = build('calendar', 'v3', credentials=creds)
+                calendar_list = service.calendarList().list().execute()
+                
+                for cal in calendar_list.get('items', []):
+                    calendars.append({
+                        'id': cal['id'],
+                        'summary': cal.get('summary', cal['id'])
+                    })
+                    
+    except Exception as e: # pylint: disable=broad-exception-caught
+        app.logger.error("Error fetching calendars: %s", e)
+    
+    return calendars
+
 @app.route('/create_sync', methods=['GET', 'POST'])
 def create_sync():
     user = session.get('user')
@@ -218,17 +257,7 @@ def create_sync():
         return redirect(url_for('login'))
 
     if request.method == 'GET':
-        # TODO: In a real app, we might fetch the user's calendars here using their stored credentials
-        # and pass them to the template to populate a dropdown.
-        # For now, we'll let them type it in or future task will add the list.
-        # Actually, let's fetch them if we can (requires using stored credentials).
-        # We'll skip fetching for this iteration to keep it simple as requested ("Ignore the syncing mechanism for now... create all the UI flows")
-        # BUT the plan said "Select a destination calendar (from a list fetched via API)".
-        # Let's try to do it if we have credentials.
-
-        calendars = []
-        # Placeholder for fetching calendars logic
-
+        calendars = fetch_user_calendars(user['uid'])
         return render_template('create_sync.html', user=user, calendars=calendars)
 
     if request.method == 'POST':

--- a/app/app.py
+++ b/app/app.py
@@ -216,7 +216,6 @@ def oauth2callback():
 def fetch_user_calendars(user_uid):
     """Fetch user's Google Calendars using stored refresh token."""
     calendars = []
-    print(f"DEBUG: Starting fetch_user_calendars for {user_uid}")
     try:
         db = firestore.client()
         user_ref = db.collection('users').document(user_uid)
@@ -227,7 +226,6 @@ def fetch_user_calendars(user_uid):
             refresh_token = user_data.get('refresh_token')
             
             if refresh_token:
-                print(f"DEBUG: Found refresh token for {user_uid}, building credentials...")
                 client_config = get_client_config()
                 creds = Credentials(
                     None, # No access token initially
@@ -238,25 +236,16 @@ def fetch_user_calendars(user_uid):
                     scopes=SCOPES
                 )
                 
-                print("DEBUG: Calling Google Calendar API...")
                 service = build('calendar', 'v3', credentials=creds)
                 calendar_list = service.calendarList().list().execute()
                 
-                items = calendar_list.get('items', [])
-                print(f"DEBUG: Calendar API response items count: {len(items)}")
-                
-                for cal in items:
+                for cal in calendar_list.get('items', []):
                     calendars.append({
                         'id': cal['id'],
                         'summary': cal.get('summary', cal['id'])
                     })
-            else:
-                print(f"DEBUG: No refresh token found for user {user_uid}")
-        else:
-             print(f"DEBUG: User document not found for {user_uid}")
                     
     except Exception as e: # pylint: disable=broad-exception-caught
-        print(f"DEBUG: Error fetching calendars: {e}")
         app.logger.error("Error fetching calendars: %s", e)
     
     return calendars

--- a/app/templates/create_sync.html
+++ b/app/templates/create_sync.html
@@ -109,11 +109,19 @@
         <form action="/create_sync" method="POST">
             <div class="form-group">
                 <label for="destination_calendar_id">Destination Calendar</label>
-                <!-- In future, populate this with real calendars -->
+                {% if calendars %}
+                <select id="destination_calendar_id" name="destination_calendar_id" required>
+                    <option value="" disabled selected>Select a calendar</option>
+                    {% for cal in calendars %}
+                    <option value="{{ cal.id }}">{{ cal.summary }}</option>
+                    {% endfor %}
+                </select>
+                {% else %}
+                <!-- Fallback if no calendars found or error -->
                 <input type="text" id="destination_calendar_id" name="destination_calendar_id"
                     placeholder="e.g., primary or calendar_id@group.calendar.google.com" required>
-                <div class="helper-text">Enter the ID of the Google Calendar you want to sync events TO. Use 'primary'
-                    for your main calendar.</div>
+                {% endif %}
+                <div class="helper-text">Select the Google Calendar you want to sync events TO.</div>
             </div>
 
             <div class="form-group">

--- a/app/templates/create_sync.html
+++ b/app/templates/create_sync.html
@@ -111,9 +111,11 @@
                 <label for="destination_calendar_id">Destination Calendar</label>
                 {% if calendars %}
                 <select id="destination_calendar_id" name="destination_calendar_id" required>
-                    <option value="" disabled selected>Select a calendar</option>
+                    <option value="" disabled {% if not calendars|selectattr("summary", "equalto" , "Family" )|list
+                        %}selected{% endif %}>Select a calendar</option>
                     {% for cal in calendars %}
-                    <option value="{{ cal.id }}">{{ cal.summary }}</option>
+                    <option value="{{ cal.id }}" {% if cal.summary=='Family' %}selected{% endif %}>{{ cal.summary }}
+                    </option>
                     {% endfor %}
                 </select>
                 {% else %}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,6 +26,11 @@ resource "google_project_service" "run_api" {
   disable_on_destroy = false
 }
 
+resource "google_project_service" "calendar_api" {
+  service            = "calendar-json.googleapis.com"
+  disable_on_destroy = false
+}
+
 resource "google_project_service" "artifact_registry_api" {
   service            = "artifactregistry.googleapis.com"
   disable_on_destroy = false


### PR DESCRIPTION
This PR adds functionality to fetch the user's Google Calendars and allow them to select one from a dropdown when creating a sync.

## Changes
- Backend: Added `fetch_user_calendars` helper to retrieve calendar list using stored credentials.
- Backend: Updated `/create_sync` route to pass calendar list to template.
- Frontend: Replaced text input with `<select>` dropdown in `create_sync.html`.

## Verification
- Verified locally that the dropdown is populated with user's calendars.
- Ran pylint to ensure code quality.