### PR TITLE
feat: Per-Source Prefixes and Removable Sources

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -383,13 +383,26 @@ def edit_sync(sync_id):
     return "Method not allowed", 405
 
 
+def _get_sources_from_form(form):
+    """Helper to extract sources from form data."""
+    urls = form.getlist("source_urls")
+    prefixes = form.getlist("source_prefixes")
+    sources = []
+    for i, url in enumerate(urls):
+        url = url.strip()
+        if not url:
+            continue
+        prefix = ""
+        if i < len(prefixes):
+            prefix = prefixes[i].strip()
+        sources.append({"url": url, "prefix": prefix})
+    return sources
+
+
 def _handle_edit_sync_post(req, sync_ref, calendars):
     """Handle POST request for edit_sync."""
     destination_id = req.form.get("destination_calendar_id")
-    ical_urls = req.form.getlist("ical_urls")
-    event_prefix = req.form.get("event_prefix", "").strip()
-
-    ical_urls = [url for url in ical_urls if url.strip()]
+    sources = _get_sources_from_form(req.form)
 
     if not destination_id:
         return "Destination Calendar ID is required", 400
@@ -405,7 +418,8 @@ def _handle_edit_sync_post(req, sync_ref, calendars):
     # Re-fetch source names
     source_names = {}
     try:
-        for url in ical_urls:
+        for source in sources:
+            url = source["url"]
             source_names[url] = get_calendar_name_from_ical(url)
     except Exception as e:  # pylint: disable=broad-exception-caught
         app.logger.warning("Failed to refresh names on edit: %s", e)
@@ -414,9 +428,8 @@ def _handle_edit_sync_post(req, sync_ref, calendars):
         {
             "destination_calendar_id": destination_id,
             "destination_calendar_summary": destination_summary,
-            "source_icals": ical_urls,
+            "sources": sources,
             "source_names": source_names,
-            "event_prefix": event_prefix,
             "updated_at": firestore.SERVER_TIMESTAMP,  # pylint: disable=no-member
         }
     )
@@ -459,12 +472,18 @@ def _calculate_end_time(start_dt_prop, duration_prop):
     return {"date": end_dt_obj.isoformat()}
 
 
-def _fetch_source_events(source_icals):
-    """Fetch and parse events from source iCal URLs."""
-    all_events = []
+def _fetch_source_events(sources):
+    """
+    Fetch and parse events from source iCal URLs.
+    Returns a list of dicts: {'component': event, 'prefix': prefix}
+    """
+    all_events_items = []
     source_names = {}
 
-    for url in source_icals:
+    for source in sources:
+        url = source["url"]
+        prefix = source.get("prefix", "")
+
         try:
             response = safe_requests_get(url, timeout=10)
             response.raise_for_status()
@@ -476,7 +495,7 @@ def _fetch_source_events(source_icals):
 
             for component in cal.walk():
                 if component.name == "VEVENT":
-                    all_events.append(component)
+                    all_events_items.append({"component": component, "prefix": prefix})
         except (
             requests.exceptions.RequestException,
             ValueError,
@@ -484,11 +503,14 @@ def _fetch_source_events(source_icals):
             app.logger.error("Failed to fetch/parse %s: %s", url, e)
             source_names[url] = f"{url} (Failed)"
 
-    return all_events, source_names
+    return all_events_items, source_names
 
 
-def _batch_upsert_events(service, destination_id, events, event_prefix):
-    """Batch upsert events to Google Calendar."""
+def _batch_upsert_events(service, destination_id, events_items):
+    """
+    Batch upsert events to Google Calendar.
+    events_items: list of {'component': event_obj, 'prefix': str}
+    """
     # pylint: disable=no-member
     batch = service.new_batch_http_request()
 
@@ -496,7 +518,10 @@ def _batch_upsert_events(service, destination_id, events, event_prefix):
         if exception:
             app.logger.error("Failed to import event %s: %s", request_id, exception)
 
-    for event in events:
+    for item in events_items:
+        event = item["component"]
+        prefix = item["prefix"]
+
         uid = event.get("UID")
         if not uid:
             continue
@@ -512,8 +537,8 @@ def _batch_upsert_events(service, destination_id, events, event_prefix):
             continue
 
         summary = str(event.get("SUMMARY", ""))
-        if event_prefix:
-            summary = f"[{event_prefix}] {summary}"
+        if prefix:
+            summary = f"[{prefix}] {summary}"
 
         body = {
             "summary": summary,
@@ -574,14 +599,21 @@ def sync_calendar_logic(sync_id):
 
     user_id = sync_data["user_id"]
     destination_id = sync_data["destination_calendar_id"]
-    source_icals = sync_data["source_icals"]
-    event_prefix = sync_data.get("event_prefix", "").strip()
+
+    # Backward compatibility: Construct sources if missing
+    sources = sync_data.get("sources")
+    if not sources:
+        sources = []
+        old_icals = sync_data.get("source_icals", [])
+        old_prefix = sync_data.get("event_prefix", "").strip()
+        for url in old_icals:
+            sources.append({"url": url, "prefix": old_prefix})
 
     # 1. Get User Credentials
     service = _get_google_service(db, user_id)
 
     # 2. Fetch and Parse
-    all_events, source_names = _fetch_source_events(source_icals)
+    all_events_items, source_names = _fetch_source_events(sources)
 
     # Update source names and last sync time
     sync_ref.update(
@@ -592,19 +624,15 @@ def sync_calendar_logic(sync_id):
     )
 
     # 3. Process Events
-    _batch_upsert_events(service, destination_id, all_events, event_prefix)
+    _batch_upsert_events(service, destination_id, all_events_items)
 
 
 def _handle_create_sync_post(user):
     destination_id = request.form.get("destination_calendar_id")
-    ical_urls = request.form.getlist("ical_urls")
-    # Filter empty URLs
-    ical_urls = [url for url in ical_urls if url.strip()]
+    sources = _get_sources_from_form(request.form)
 
     if not destination_id:
         return "Destination Calendar ID is required", 400
-
-    event_prefix = request.form.get("event_prefix", "").strip()
 
     # Lookup destination summary from cached calendars
     destination_summary = destination_id
@@ -635,8 +663,7 @@ def _handle_create_sync_post(user):
             "user_id": user["uid"],
             "destination_calendar_id": destination_id,
             "destination_calendar_summary": destination_summary,
-            "source_icals": ical_urls,
-            "event_prefix": event_prefix,
+            "sources": sources,
             "created_at": firestore.SERVER_TIMESTAMP,  # pylint: disable=no-member
         }
     )
@@ -644,7 +671,8 @@ def _handle_create_sync_post(user):
     # Populate source names asynchronously (or just do it now for simplicity)
     try:
         source_names = {}
-        for url in ical_urls:
+        for source in sources:
+            url = source["url"]
             source_names[url] = get_calendar_name_from_ical(url)
         new_sync_ref.update({"source_names": source_names})
     except Exception as e:  # pylint: disable=broad-exception-caught

--- a/app/app.py
+++ b/app/app.py
@@ -8,6 +8,7 @@ import logging
 import time
 from datetime import datetime, timezone
 import json
+import re
 from flask import Flask, render_template, request, session, redirect, url_for
 from werkzeug.middleware.proxy_fix import ProxyFix
 import firebase_admin
@@ -397,9 +398,7 @@ def _get_sources_from_form(form):
     urls = form.getlist("source_urls")
     prefixes = form.getlist("source_prefixes")
     sources = []
-    
-    import re
-    
+
     for i, url in enumerate(urls):
         url = url.strip()
         if not url:
@@ -409,8 +408,8 @@ def _get_sources_from_form(form):
             raw_prefix = prefixes[i].strip()
             # Allow alphanumerics, spaces, dashes, underscores, brackets
             # Remove anything else to prevent HTML injection etc.
-            prefix = re.sub(r'[^a-zA-Z0-9 \-_\[\]\(\)]', '', raw_prefix)
-            
+            prefix = re.sub(r"[^a-zA-Z0-9 \-_\[\]\(\)]", "", raw_prefix)
+
         sources.append({"url": url, "prefix": prefix})
     return sources
 

--- a/app/templates/create_sync.html
+++ b/app/templates/create_sync.html
@@ -22,7 +22,7 @@
             border-radius: 8px;
             box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
             width: 100%;
-            max-width: 600px;
+            max-width: 800px;
         }
 
         h1 {
@@ -81,6 +81,20 @@
         .btn-secondary:hover {
             background-color: #f1f1f1;
         }
+        
+        .btn-danger {
+            background-color: #dc3545;
+            color: white;
+            padding: 0.5rem 1rem;
+            font-size: 0.9rem;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        
+        .btn-danger:hover {
+            background-color: #c82333;
+        }
 
         .ical-list {
             margin-top: 0.5rem;
@@ -90,6 +104,15 @@
             display: flex;
             gap: 0.5rem;
             margin-bottom: 0.5rem;
+            align-items: center;
+        }
+        
+        .ical-entry input[name="source_urls"] {
+            flex: 3;
+        }
+        
+        .ical-entry input[name="source_prefixes"] {
+            flex: 1;
         }
 
         .add-btn {
@@ -127,19 +150,18 @@
             </div>
 
             <div class="form-group">
-                <label>Source iCal URLs</label>
+                <label>Source Calendars</label>
+                <div class="helper-text" style="margin-bottom: 0.5rem;">
+                    Enter the iCal URL and an optional prefix for events from this source.
+                </div>
                 <div id="ical-container">
                     <div class="ical-entry">
-                        <input type="text" name="ical_urls" placeholder="https://example.com/calendar.ics">
+                        <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics" required>
+                        <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Work)">
+                        <button type="button" class="btn btn-danger" onclick="removeEntry(this)" style="visibility: hidden;">Remove</button>
                     </div>
                 </div>
-                <button type="button" class="add-btn" onclick="addIcalInput()">+ Add another URL</button>
-            </div>
-
-            <div class="form-group">
-                <label for="event_prefix">Event Prefix (Optional)</label>
-                <input type="text" id="event_prefix" name="event_prefix" placeholder="e.g. School">
-                <div class="helper-text">This prefix will be added to the title of every synced event.</div>
+                <button type="button" class="add-btn" onclick="addIcalInput()">+ Add another Source</button>
             </div>
 
             <div class="buttons">
@@ -154,8 +176,31 @@
             const container = document.getElementById('ical-container');
             const div = document.createElement('div');
             div.className = 'ical-entry';
-            div.innerHTML = '<input type="text" name="ical_urls" placeholder="https://example.com/calendar.ics">';
+            div.innerHTML = `
+                <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics" required>
+                <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Gym)">
+                <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
+            `;
             container.appendChild(div);
+            updateRemoveButtons();
+        }
+
+        function removeEntry(btn) {
+            const entry = btn.closest('.ical-entry');
+            entry.remove();
+            updateRemoveButtons();
+        }
+        
+        function updateRemoveButtons() {
+            const entries = document.querySelectorAll('.ical-entry');
+            entries.forEach((entry, index) => {
+                const btn = entry.querySelector('.btn-danger');
+                if (entries.length === 1) {
+                    btn.style.visibility = 'hidden';
+                } else {
+                    btn.style.visibility = 'visible';
+                }
+            });
         }
     </script>
 </body>

--- a/app/templates/create_sync.html
+++ b/app/templates/create_sync.html
@@ -81,7 +81,7 @@
         .btn-secondary:hover {
             background-color: #f1f1f1;
         }
-        
+
         .btn-danger {
             background-color: #dc3545;
             color: white;
@@ -91,7 +91,7 @@
             border-radius: 4px;
             cursor: pointer;
         }
-        
+
         .btn-danger:hover {
             background-color: #c82333;
         }
@@ -106,11 +106,11 @@
             margin-bottom: 0.5rem;
             align-items: center;
         }
-        
+
         .ical-entry input[name="source_urls"] {
             flex: 3;
         }
-        
+
         .ical-entry input[name="source_prefixes"] {
             flex: 1;
         }
@@ -158,7 +158,8 @@
                     <div class="ical-entry">
                         <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics" required>
                         <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Work)">
-                        <button type="button" class="btn btn-danger" onclick="removeEntry(this)" style="visibility: hidden;">Remove</button>
+                        <button type="button" class="btn btn-danger" onclick="removeEntry(this)"
+                            style="visibility: hidden;">Remove</button>
                     </div>
                 </div>
                 <button type="button" class="add-btn" onclick="addIcalInput()">+ Add another Source</button>
@@ -171,17 +172,20 @@
         </form>
     </div>
 
+    <template id="source-entry-template">
+        <div class="ical-entry">
+            <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics" required>
+            <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Gym)">
+            <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
+        </div>
+    </template>
+
     <script>
         function addIcalInput() {
             const container = document.getElementById('ical-container');
-            const div = document.createElement('div');
-            div.className = 'ical-entry';
-            div.innerHTML = `
-                <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics" required>
-                <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Gym)">
-                <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
-            `;
-            container.appendChild(div);
+            const template = document.getElementById('source-entry-template');
+            const clone = template.content.cloneNode(true);
+            container.appendChild(clone);
             updateRemoveButtons();
         }
 
@@ -190,7 +194,7 @@
             entry.remove();
             updateRemoveButtons();
         }
-        
+
         function updateRemoveButtons() {
             const entries = document.querySelectorAll('.ical-entry');
             entries.forEach((entry, index) => {

--- a/app/templates/edit_sync.html
+++ b/app/templates/edit_sync.html
@@ -22,7 +22,7 @@
             border-radius: 8px;
             box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
             width: 100%;
-            max-width: 600px;
+            max-width: 800px;
         }
 
         h1 {
@@ -82,14 +82,33 @@
             background-color: #f1f1f1;
         }
 
-        .ical-list {
-            margin-top: 0.5rem;
+        .btn-danger {
+            background-color: #dc3545;
+            color: white;
+            padding: 0.5rem 1rem;
+            font-size: 0.9rem;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+
+        .btn-danger:hover {
+            background-color: #c82333;
         }
 
         .ical-entry {
             display: flex;
             gap: 0.5rem;
             margin-bottom: 0.5rem;
+            align-items: center;
+        }
+
+        .ical-entry input[name="source_urls"] {
+            flex: 3;
+        }
+
+        .ical-entry input[name="source_prefixes"] {
+            flex: 1;
         }
 
         .add-btn {
@@ -126,29 +145,40 @@
             </div>
 
             <div class="form-group">
-                <label>Source iCal URLs</label>
+                <label>Source Calendars</label>
+                <div class="helper-text" style="margin-bottom: 0.5rem;">
+                    Enter the iCal URL and an optional prefix for events from this source.
+                </div>
                 <div id="ical-container">
+                    {% set sources = sync.sources %}
+                    {% if not sources and sync.source_icals %}
+                    {# Backward compatibility for old data model #}
+                    {% set sources = [] %}
                     {% for url in sync.source_icals %}
+                    {% set _ = sources.append({'url': url, 'prefix': sync.event_prefix}) %}
+                    {% endfor %}
+                    {% endif %}
+
+                    {% for source in sources %}
                     <div class="ical-entry">
-                        <input type="text" name="ical_urls" value="{{ url }}"
-                            placeholder="https://example.com/calendar.ics">
+                        <input type="text" name="source_urls" value="{{ source.url }}"
+                            placeholder="https://example.com/calendar.ics" required>
+                        <input type="text" name="source_prefixes" value="{{ source.prefix or '' }}"
+                            placeholder="Prefix (e.g. Work)">
+                        <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
                     </div>
                     {% endfor %}
-                    <!-- Ensure at least one input if empty, though ideally shouldn't be -->
-                    {% if not sync.source_icals %}
+
+                    {% if not sources %}
                     <div class="ical-entry">
-                        <input type="text" name="ical_urls" placeholder="https://example.com/calendar.ics">
+                        <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics" required>
+                        <input type="text" name="source_prefixes" placeholder="Prefix (e.g. School)">
+                        <button type="button" class="btn btn-danger" onclick="removeEntry(this)"
+                            style="visibility: hidden;">Remove</button>
                     </div>
                     {% endif %}
                 </div>
-                <button type="button" class="add-btn" onclick="addIcalInput()">+ Add another URL</button>
-            </div>
-
-            <div class="form-group">
-                <label for="event_prefix">Event Prefix (Optional)</label>
-                <input type="text" id="event_prefix" name="event_prefix" value="{{ sync.event_prefix or '' }}"
-                    placeholder="e.g. School">
-                <div class="helper-text">This prefix will be added to the title of every synced event.</div>
+                <button type="button" class="add-btn" onclick="addIcalInput()">+ Add another Source</button>
             </div>
 
             <div class="buttons">
@@ -163,9 +193,35 @@
             const container = document.getElementById('ical-container');
             const div = document.createElement('div');
             div.className = 'ical-entry';
-            div.innerHTML = '<input type="text" name="ical_urls" placeholder="https://example.com/calendar.ics">';
+            div.innerHTML = `
+                <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics" required>
+                <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Gym)">
+                <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
+            `;
             container.appendChild(div);
+            updateRemoveButtons();
         }
+
+        function removeEntry(btn) {
+            const entry = btn.closest('.ical-entry');
+            entry.remove();
+            updateRemoveButtons();
+        }
+
+        function updateRemoveButtons() {
+            const entries = document.querySelectorAll('.ical-entry');
+            entries.forEach((entry, index) => {
+                const btn = entry.querySelector('.btn-danger');
+                if (entries.length === 1) {
+                    btn.style.visibility = 'hidden';
+                } else {
+                    btn.style.visibility = 'visible';
+                }
+            });
+        }
+
+        // Initial setup for remove buttons
+        document.addEventListener('DOMContentLoaded', updateRemoveButtons);
     </script>
 </body>
 

--- a/app/templates/edit_sync.html
+++ b/app/templates/edit_sync.html
@@ -150,16 +150,7 @@
                     Enter the iCal URL and an optional prefix for events from this source.
                 </div>
                 <div id="ical-container">
-                    {% set sources = sync.sources %}
-                    {% if not sources and sync.source_icals %}
-                    {# Backward compatibility for old data model #}
-                    {% set sources = [] %}
-                    {% for url in sync.source_icals %}
-                    {% set _ = sources.append({'url': url, 'prefix': sync.event_prefix}) %}
-                    {% endfor %}
-                    {% endif %}
-
-                    {% for source in sources %}
+                    {% for source in sync.sources %}
                     <div class="ical-entry">
                         <input type="text" name="source_urls" value="{{ source.url }}"
                             placeholder="https://example.com/calendar.ics" required>
@@ -188,17 +179,20 @@
         </form>
     </div>
 
+    <template id="source-entry-template">
+        <div class="ical-entry">
+            <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics" required>
+            <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Gym)">
+            <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
+        </div>
+    </template>
+
     <script>
         function addIcalInput() {
             const container = document.getElementById('ical-container');
-            const div = document.createElement('div');
-            div.className = 'ical-entry';
-            div.innerHTML = `
-                <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics" required>
-                <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Gym)">
-                <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
-            `;
-            container.appendChild(div);
+            const template = document.getElementById('source-entry-template');
+            const clone = template.content.cloneNode(true);
+            container.appendChild(clone);
             updateRemoveButtons();
         }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -204,20 +204,27 @@
                             <h3 class="sync-title">
                                 To: {{ sync.destination_calendar_summary or sync.destination_calendar_id }}
                             </h3>
-                            {% if sync.event_prefix %}
-                            <p class="sync-prefix">
-                                <strong>Prefix:</strong> <span class="prefix-badge">[{{
-                                    sync.event_prefix }}]</span>
-                            </p>
-                            {% endif %}
                             <p class="source-label"><strong>Sources:</strong></p>
                             <ul class="source-list">
-                                {% for source in sync.source_icals %}
+                                {% set sources = sync.sources %}
+                                {% if not sources and sync.source_icals %}
+                                {# Backward compatibility #}
+                                {% set sources = [] %}
+                                {% for url in sync.source_icals %}
+                                {% set _ = sources.append({'url': url, 'prefix': sync.event_prefix}) %}
+                                {% endfor %}
+                                {% endif %}
+
+                                {% for source in sources %}
                                 <li>
-                                    {% if sync.source_names and sync.source_names[source] %}
-                                    {{ sync.source_names[source] }}
+                                    {% if source.prefix %}
+                                    <span class="prefix-badge">[{{ source.prefix }}]</span>
+                                    {% endif %}
+
+                                    {% if sync.source_names and sync.source_names[source.url] %}
+                                    {{ sync.source_names[source.url] }}
                                     {% else %}
-                                    <span class="source-url">{{ source }}</span>
+                                    <span class="source-url">{{ source.url }}</span>
                                     {% endif %}
                                 </li>
                                 {% endfor %}

--- a/tests/test_sync_logic.py
+++ b/tests/test_sync_logic.py
@@ -39,7 +39,7 @@ class TestSyncLogic(unittest.TestCase):
         mock_user_ref = MagicMock()
         mock_user_doc = MagicMock()
         mock_user_doc.to_dict.return_value = {"refresh_token": "dummy_token"}
-        
+
         mock_sync_col = MagicMock()
         mock_sync_col.document.return_value = mock_sync_ref
 
@@ -115,7 +115,7 @@ class TestSyncLogic(unittest.TestCase):
             "sources": [
                 {"url": "http://site1.com/cal.ics", "prefix": "P1"},
                 {"url": "http://site2.com/cal.ics", "prefix": "P2"},
-            ]
+            ],
         }
         mock_db.collection.return_value.document.return_value = mock_sync_ref
         mock_sync_ref.get.return_value = mock_sync_doc
@@ -123,7 +123,7 @@ class TestSyncLogic(unittest.TestCase):
         mock_user_ref = MagicMock()
         mock_user_doc = MagicMock()
         mock_user_doc.to_dict.return_value = {"refresh_token": "dummy_token"}
-        
+
         mock_sync_col = MagicMock()
         mock_sync_col.document.return_value = mock_sync_ref
         mock_user_col = MagicMock()
@@ -135,6 +135,7 @@ class TestSyncLogic(unittest.TestCase):
             if name == "users":
                 return mock_user_col
             return MagicMock()
+
         mock_db.collection.side_effect = collection_side_effect
 
         # Mock requests.get to return different content based on URL
@@ -156,7 +157,7 @@ class TestSyncLogic(unittest.TestCase):
                     b"END:VEVENT\r\nEND:VCALENDAR"
                 )
             return resp
-        
+
         mock_get.side_effect = get_side_effect
 
         # Mock Service
@@ -170,7 +171,7 @@ class TestSyncLogic(unittest.TestCase):
 
         # Verify
         self.assertEqual(mock_batch.add.call_count, 2)
-        
+
         # Check calls
         # We need to find which call is which based on iCalUID or Summary
         calls = mock_service.events.return_value.import_.call_args_list
@@ -178,10 +179,9 @@ class TestSyncLogic(unittest.TestCase):
         for call_args in calls:
             _, kwargs = call_args
             summaries.append(kwargs["body"]["summary"])
-        
+
         self.assertIn("[P1] Event One", summaries)
         self.assertIn("[P2] Event Two", summaries)
-
 
     @patch("app.app.firestore.client")
     @patch("app.app.get_client_config")


### PR DESCRIPTION
Refactors the sync logic to support defining prefixes for individual sync sources, rather than a single global prefix for the entire sync.

### Changes
- Updated `sync` data model to use a `sources` list of objects `{'url': ..., 'prefix': ...}`.
- Updated `create_sync` and `edit_sync` templates to manage sources dynamically.
- Refactored `app.py` logic to process events with their specific prefixes.
- Added backward compatibility for existing syncs.
- Updated unit tests.