### PR TITLE
feat: Migrate static asset hosting to Firebase Hosting

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,7 @@
+{
+  "projects": {
+    "default": "calendarsync-napier-dev",
+    "dev": "calendarsync-napier-dev",
+    "prod": "calendarsync-napier"
+  }
+}

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -73,6 +73,29 @@ jobs:
           region: ${{ inputs.region }}
           image: ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/${{ inputs.service_name }}/${{ inputs.service_name }}:${{ github.sha }}
 
+      - name: Deploy to Firebase Hosting
+        # Only run if firebase.json exists
+        if: hashFiles('firebase.json') != ''
+        run: |
+          # 1. Install Firebase Tools
+          npm install -g firebase-tools
+
+          # 2. Prepare Public Directory
+          mkdir -p public/static
+          if [ -d "app/static" ]; then
+            cp -r app/static/* public/static/
+          fi
+
+          # 3. Configure firebase.json with correct service name
+          # Replace SERVICE_NAME with the actual input service name
+          sed -i 's/SERVICE_NAME/${{ inputs.service_name }}/g' firebase.json
+
+          # 4. Deploy to Firebase
+          # We use the project_id from inputs
+          firebase deploy --only hosting --project ${{ inputs.project_id }} --non-interactive
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
+
       - name: Smoke Test
         run: |
           TARGET_URL="${{ inputs.custom_url }}"

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,19 @@
+{
+    "hosting": {
+        "public": "public",
+        "ignore": [
+            "firebase.json",
+            "**/.*",
+            "**/node_modules/**"
+        ],
+        "rewrites": [
+            {
+                "source": "**",
+                "run": {
+                    "serviceId": "SERVICE_NAME",
+                    "region": "us-central1"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Firebase Hosting Migration

This PR migrates the serving of static assets (CSS, images, JS) from Flask/Cloud Run to Firebase Hosting.

### Changes
- **Configuration**:
    - Added `firebase.json` with a placeholder `SERVICE_NAME` for dynamic rewrites.
    - Added `.firebaserc` with project aliases.
- **CI/CD (`reusable-deploy.yml`)**:
    - Added a new step: "Deploy to Firebase Hosting".
    - Installs `firebase-tools`.
    - Creates a `public/static` directory and copies assets.
    - Dynamically configures `firebase.json` to point rewrites to the correct Cloud Run service (`python-cloudrun-app` for prod, `calendarsync-dev` for dev).
    - Deploys using `firebase deploy`.

### Verification
- Deployment workflow should now include "Deploy to Firebase Hosting".
- Static assets should be accessible via the Firebase Hosting URL (e.g., `/static/style.css`).
- Rewrites should forward dynamic requests to Cloud Run as before.