### PR TITLE
feat: Add Google Calendar Source and Fix Firebase Cookie

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Install Black
         run: |
-          pip install black
+          pip install black==25.12.0
 
       - name: Check code formatting with Black
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,11 @@ Welcome! We appreciate your interest in contributing to the Calendar Sync projec
         pylint app tests
         ```
         *Target Score: >= 8.0*
-    *   **Code Formatting**: Run `black` on the `app` and `tests` directories.
+    *   **Code Formatting**: Run `black` to automatically fix formatting issues.
         ```bash
-        black --check app tests
+        black .
         ```
-        *Requirement: No formatting changes needed.*
+        *Requirement: You MUST run this before every push to prevent CI failures.*
     *   **Python Tests**: Run the full test suite.
         ```bash
         pytest

--- a/app/app.py
+++ b/app/app.py
@@ -580,9 +580,14 @@ def _handle_edit_sync_post(req, sync_ref, calendars):
             "destination_calendar_summary": destination_summary,
             "sources": sources,
             "source_names": source_names,
-            "updated_at": firestore.SERVER_TIMESTAMP,  # pylint: disable=no-member
         }
     )
+
+    # Auto-sync immediately after edit
+    try:
+        sync_calendar_logic(sync_ref.id)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        app.logger.warning("Auto-sync on edit failed: %s", e)
 
     return redirect(url_for("home"))
 
@@ -929,6 +934,12 @@ def _handle_create_sync_post(user):
         new_sync_ref.update({"source_names": source_names})
     except Exception as e:  # pylint: disable=broad-exception-caught
         app.logger.warning("Failed to populate initial source names: %s", e)
+
+    # Auto-sync immediately after creation
+    try:
+        sync_calendar_logic(new_sync_ref.id)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        app.logger.warning("Auto-sync on create failed: %s", e)
 
     return redirect(url_for("home"))
 

--- a/app/app.py
+++ b/app/app.py
@@ -549,7 +549,6 @@ def _get_sources_from_form(form):
     return sources
 
 
-
 def _resolve_source_names(sources, calendars):
     """
     Efficiently resolve friendly names for sources.
@@ -557,7 +556,7 @@ def _resolve_source_names(sources, calendars):
     - calendars: list of Google Calendar dicts (id, summary)
     """
     source_names = {}
-    
+
     # Create a lookup map for calendar names for efficiency
     cal_map = {cal["id"]: cal["summary"] for cal in calendars} if calendars else {}
 
@@ -571,12 +570,11 @@ def _resolve_source_names(sources, calendars):
                 source_names[url] = get_calendar_name_from_ical(url)
     except Exception as e:  # pylint: disable=broad-exception-caught
         app.logger.warning("Failed to resolve source names: %s", e)
-        
+
     return source_names
 
 
 def _handle_edit_sync_post(req, sync_ref, calendars):
-
     """Handle POST request for edit_sync."""
     destination_id = req.form.get("destination_calendar_id")
     sources = _get_sources_from_form(req.form)
@@ -679,19 +677,17 @@ def _fetch_google_source(source, user_id):
                 )
                 .execute()
             )
-            
+
             items = events_result.get("items", [])
             events.extend(items)
 
             if page_token is None:
-                 # The summary is the same for all pages, so we can get it from the first response.
+                # The summary is the same for all pages, so we can get it from the first response.
                 name = events_result.get("summary", url)
 
             page_token = events_result.get("nextPageToken")
             if not page_token:
                 break
-
-
 
         for gevent in events:
             ievent = icalendar.Event()

--- a/app/app.py
+++ b/app/app.py
@@ -570,7 +570,17 @@ def _handle_edit_sync_post(req, sync_ref, calendars):
     try:
         for source in sources:
             url = source["url"]
-            source_names[url] = get_calendar_name_from_ical(url)
+            if source.get("type") == "google":
+                # Try to find name in calendars
+                found_name = source["id"]
+                if calendars:
+                    for cal in calendars:
+                        if cal["id"] == source["id"]:
+                            found_name = cal["summary"]
+                            break
+                source_names[url] = found_name
+            else:
+                source_names[url] = get_calendar_name_from_ical(url)
     except Exception as e:  # pylint: disable=broad-exception-caught
         app.logger.warning("Failed to refresh names on edit: %s", e)
 
@@ -926,11 +936,22 @@ def _handle_create_sync_post(user):
     )
 
     # Populate source names asynchronously (or just do it now for simplicity)
+    # Populate source names asynchronously (or just do it now for simplicity)
     try:
         source_names = {}
         for source in sources:
             url = source["url"]
-            source_names[url] = get_calendar_name_from_ical(url)
+            if source.get("type") == "google":
+                # Try to find name in user_calendars
+                found_name = source["id"]
+                if user_calendars:
+                    for cal in user_calendars:
+                        if cal["id"] == source["id"]:
+                            found_name = cal["summary"]
+                            break
+                source_names[url] = found_name
+            else:
+                source_names[url] = get_calendar_name_from_ical(url)
         new_sync_ref.update({"source_names": source_names})
     except Exception as e:  # pylint: disable=broad-exception-caught
         app.logger.warning("Failed to populate initial source names: %s", e)

--- a/app/app.py
+++ b/app/app.py
@@ -50,6 +50,11 @@ app = Flask(__name__)
 # Fix for Cloud Run (HTTPS behind proxy)
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_port=1)
 
+# Firebase Hosting requires the session cookie to be named '__session'
+app.config['SESSION_COOKIE_NAME'] = '__session'
+app.config['SESSION_COOKIE_SECURE'] = True
+app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
+
 logging.basicConfig(level=logging.INFO)
 
 # Configuration

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -5,9 +5,11 @@
     --text-light: #5f6368;
     --bg-light: #f8f9fa;
     --white: #ffffff;
+    --border-color: #dadce0;
+    --success-color: #1e8e3e;
+    --danger-color: #d93025;
     --shadow-sm: 0 1px 2px 0 rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);
     --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-    --border-color-light: #eee;
     --font-stack: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
 
@@ -16,7 +18,7 @@ body {
     margin: 0;
     padding: 0;
     color: var(--text-dark);
-    background-color: var(--white);
+    background-color: var(--bg-light);
     line-height: 1.5;
     display: flex;
     flex-direction: column;
@@ -46,14 +48,14 @@ body {
 }
 
 .logo-img {
-    height: 40px;
+    height: 32px;
     width: auto;
 }
 
 .logo-text {
     font-size: 1.25rem;
-    font-weight: 700;
-    letter-spacing: -0.02em;
+    font-weight: 600;
+    letter-spacing: -0.01em;
 }
 
 /* Hero Section */
@@ -111,7 +113,7 @@ body {
 /* Features Section */
 .features-section {
     padding: 4rem 5%;
-    background-color: var(--bg-light);
+    background-color: var(--white);
 }
 
 .features-grid {
@@ -123,10 +125,10 @@ body {
 }
 
 .feature-card {
-    background: var(--white);
+    background: var(--bg-light);
     padding: 2rem;
     border-radius: 12px;
-    box-shadow: var(--shadow-sm);
+    border: 1px solid var(--border-color);
     transition: transform 0.2s, box-shadow 0.2s;
 }
 
@@ -151,23 +153,18 @@ body {
     color: var(--text-light);
 }
 
-/* Auth Buttons */
-.auth-wrapper {
-    margin-top: 2rem;
-}
-
 /* Footer */
 footer {
     margin-top: auto;
     padding: 2rem 5%;
     text-align: center;
     color: var(--text-light);
-    color: var(--text-light);
     font-size: 0.9rem;
-    border-top: 1px solid var(--border-color-light);
+    border-top: 1px solid var(--border-color);
+    background-color: var(--white);
 }
 
-/* Dashboard Styles (retained/updated) */
+/* Dashboard Styles */
 .user-menu {
     display: flex;
     align-items: center;
@@ -190,156 +187,250 @@ footer {
     font-weight: 500;
     text-decoration: none;
     cursor: pointer;
-    transition: background 0.2s;
+    transition: all 0.2s;
+    font-size: 0.95rem;
+    border: 1px solid transparent;
 }
 
 .btn-primary {
     background-color: var(--primary-color);
     color: white;
-    border: none;
 }
 
 .btn-primary:hover {
     background-color: var(--primary-hover);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .btn-outline {
     background-color: transparent;
     color: var(--primary-color);
-    border: 1px solid var(--primary-color);
+    border-color: var(--primary-color);
 }
 
 .btn-outline:hover {
     background-color: rgba(26, 115, 232, 0.05);
 }
 
-/* Responsive */
-@media (max-width: 900px) {
-    .hero-section {
-        grid-template-columns: 1fr;
-        text-align: center;
-        padding-top: 3rem;
-    }
-
-    .hero-content {
-        margin: 0 auto;
-    }
-
-    .hero-headline {
-        font-size: 2.5rem;
-    }
+.btn-secondary {
+    background-color: white;
+    color: var(--text-dark);
+    border-color: var(--border-color);
 }
 
-/* Form & Card Styles (Migrated from templates) */
+.btn-secondary:hover {
+    background-color: var(--bg-light);
+    border-color: #ccc;
+}
+
+.btn-danger {
+    background-color: white;
+    color: var(--danger-color);
+    border-color: var(--border-color);
+    padding: 0.5rem 0.8rem;
+}
+
+.btn-danger:hover {
+    background-color: #fce8e6;
+    border-color: #f5c6cb;
+}
+
+/* Form & Card Styles */
 .form-card {
     background: var(--white);
-    padding: 2rem;
-    border-radius: 12px;
+    padding: 2.5rem;
+    border-radius: 16px;
     box-shadow: var(--shadow-sm);
     width: 100%;
-    max-width: 800px;
+    max-width: 900px;
     margin: 2rem auto;
+    border: 1px solid var(--border-color);
+}
+
+.form-header-group {
+    margin-bottom: 2rem;
+    text-align: center;
+}
+
+.form-card h1 {
+    font-size: 1.75rem;
+    margin: 0 0 0.5rem 0;
+    color: var(--text-dark);
 }
 
 .form-group {
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem;
 }
 
 label {
     display: block;
     margin-bottom: 0.5rem;
-    font-weight: 500;
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: var(--text-dark);
 }
 
 input[type="text"],
 select {
     width: 100%;
-    padding: 0.75rem;
-    border: 1px solid #ccc;
-    border-radius: 6px;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
     font-size: 1rem;
     box-sizing: border-box;
     font-family: inherit;
-    transition: border-color 0.2s;
+    transition: border-color 0.2s, box-shadow 0.2s;
+    background-color: var(--white);
 }
 
 input[type="text"]:focus,
 select:focus {
     outline: none;
     border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.1);
 }
 
-.helper-text {
+.form-hint {
     font-size: 0.85rem;
     color: var(--text-light);
-    margin-top: 0.25rem;
+    margin-top: 0.5rem;
 }
 
-.btn-secondary {
-    background-color: transparent;
-    color: var(--text-light);
-    border: 1px solid #ccc;
-    margin-right: 0.5rem;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.6rem 1.2rem;
-    border-radius: 6px;
-    font-weight: 500;
-    text-decoration: none;
-    cursor: pointer;
-    transition: background 0.2s;
-}
-
-.btn-secondary:hover {
-    background-color: #f1f1f1;
-}
-
-.btn-danger {
-    background-color: #dc3545;
-    color: white;
-    padding: 0.5rem 1rem;
+.info-box {
+    background: #e8f0fe;
+    padding: 1rem;
+    border-radius: 8px;
+    margin-bottom: 1.5rem;
     font-size: 0.9rem;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: background 0.2s;
+    color: #174ea6;
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
 }
 
-.btn-danger:hover {
-    background-color: #c82333;
+.info-box-icon {
+    font-size: 1.2rem;
+}
+
+/* Source Entry Grid */
+.source-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }
 
 .ical-entry {
+    background-color: var(--bg-light);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 1rem;
+    display: grid;
+    grid-template-columns: 180px 1fr 180px auto;
+    gap: 1rem;
+    align-items: start;
+    transition: border-color 0.2s;
+    position: relative;
+}
+
+.ical-entry:hover {
+    border-color: #ccc;
+}
+
+/* Source Type Select (First Column) */
+.source-type-group {
     display: flex;
-    gap: 0.5rem;
-    margin-bottom: 0.5rem;
+    flex-direction: column;
+}
+
+.field-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-light);
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}
+
+/* Input Fields (Second Column) */
+.source-input-group {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+.source-input-group .input-row {
+    width: 100%;
+}
+
+/* Prefix (Third Column) */
+.source-prefix-group {
+    display: flex;
+    flex-direction: column;
+}
+
+/* Actions (Fourth Column) */
+.source-actions {
+    display: flex;
     align-items: center;
+    height: 100%;
+    padding-top: 1.25rem;
+    /* Align with inputs */
 }
 
-.ical-entry input[name="source_urls"] {
-    flex: 3;
-}
-
-.ical-entry input[name="source_prefixes"] {
-    flex: 1;
-}
-
+/* Add Button */
 .add-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
     background: none;
-    border: none;
+    border: 2px dashed var(--border-color);
     color: var(--primary-color);
     cursor: pointer;
-    padding: 0;
-    font-size: 0.9rem;
+    padding: 0.75rem;
+    font-size: 0.95rem;
     font-weight: 500;
+    width: 100%;
+    border-radius: 8px;
+    justify-content: center;
+    transition: all 0.2s;
+    margin-top: 0.5rem;
 }
 
 .add-btn:hover {
-    text-decoration: underline;
+    border-color: var(--primary-color);
+    background-color: rgba(26, 115, 232, 0.05);
+    text-decoration: none;
 }
 
-/* Utility to center text if needed */
-.text-center {
-    text-align: center;
+/* Action Buttons Footer */
+.form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+    margin-top: 2rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--border-color);
+}
+
+/* Utilities */
+.hidden {
+    display: none !important;
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+    .ical-entry {
+        grid-template-columns: 1fr;
+        gap: 1rem;
+        padding: 1.25rem;
+    }
+
+    .source-actions {
+        padding-top: 0;
+        justify-content: flex-end;
+    }
+
+    .form-card {
+        padding: 1.5rem;
+    }
 }

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -325,7 +325,7 @@ select:focus {
     border-radius: 10px;
     padding: 1rem;
     display: grid;
-    grid-template-columns: 180px 1fr 180px auto;
+    grid-template-columns: minmax(140px, auto) 1fr minmax(140px, auto) auto;
     gap: 1rem;
     align-items: start;
     transition: border-color 0.2s;

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -423,8 +423,8 @@ details[open] summary.help-summary::before {
     display: flex;
     align-items: center;
     height: 100%;
-    padding-top: 1.25rem;
-    /* Align with inputs */
+    /* Align with inputs handled by hidden label in HTML */
+    padding-top: 0;
 }
 
 /* Add Button */

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -296,7 +296,57 @@ select:focus {
     margin-top: 0.5rem;
 }
 
+/* Help Box (Collapsible) */
+details.help-box {
+    background-color: transparent;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+    color: var(--text-light);
+    border: 1px solid transparent;
+    border-radius: 8px;
+    transition: all 0.2s;
+}
+
+details.help-box[open] {
+    background-color: #f8f9fa;
+    border-color: var(--border-color);
+    padding: 1rem;
+}
+
+summary.help-summary {
+    cursor: pointer;
+    font-weight: 500;
+    color: var(--primary-color);
+    list-style: none;
+    /* Hide default triangle */
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    user-select: none;
+}
+
+summary.help-summary::-webkit-details-marker {
+    display: none;
+}
+
+summary.help-summary::before {
+    content: '▶';
+    font-size: 0.7em;
+    transition: transform 0.2s;
+}
+
+details[open] summary.help-summary::before {
+    transform: rotate(90deg);
+}
+
+.help-content {
+    margin-top: 0.75rem;
+    color: var(--text-dark);
+    line-height: 1.5;
+}
+
 .info-box {
+    /* Keep for legacy or specialized uses if any, otherwise can eventually remove */
     background: #e8f0fe;
     padding: 1rem;
     border-radius: 8px;

--- a/app/templates/create_sync.html
+++ b/app/templates/create_sync.html
@@ -19,24 +19,30 @@
             {% if user %}
             <span>{{ user.name }}</span>
             <img src="{{ user.picture }}" alt="Profile" style="width: 32px; height: 32px; border-radius: 50%;">
-            <a href="/logout" class="btn btn-outline">Sign Out</a>
+            <a href="/logout" class="btn btn-outline btn-sm">Sign Out</a>
             {% endif %}
         </div>
     </header>
 
     <main class="dashboard-container">
         <div class="form-card">
-            <h1>Create New Sync</h1>
+            <div class="form-header-group">
+                <h1>Create New Sync</h1>
+                <p class="form-hint">Set up a new synchronization between calendars</p>
+            </div>
+
             <form action="/create_sync" method="POST">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+
+                <!-- Destination Section -->
                 <div class="form-group">
                     <label for="destination_calendar_id">Destination Calendar</label>
                     {% if calendars %}
                     <select id="destination_calendar_id" name="destination_calendar_id" required>
-                        <option value="" disabled {% if not calendars|selectattr("summary", "equalto" , "Family" )|list
-                            %}selected{% endif %}>Select a calendar</option>
+                        <option value="" disabled selected>Select a calendar</option>
                         {% for cal in calendars %}
-                        <option value="{{ cal.id }}" {% if cal.summary=='Family' %}selected{% endif %}>{{ cal.summary }}
+                        <option value="{{ cal.id }}" {% if cal.summary=='Family' %}selected{% endif %}>
+                            {{ cal.summary }}
                         </option>
                         {% endfor %}
                     </select>
@@ -45,70 +51,84 @@
                     <input type="text" id="destination_calendar_id" name="destination_calendar_id"
                         placeholder="e.g., primary or calendar_id@group.calendar.google.com" required>
                     {% endif %}
-                    <div class="helper-text">Select the Google Calendar you want to sync events TO.</div>
+                    <div class="form-hint">Select the Google Calendar you want to sync events TO.</div>
                 </div>
 
+                <!-- Sources Section -->
                 <div class="form-group">
                     <label>Source Calendars</label>
-                    <div class="info-box"
-                        style="background: #e8f0fe; padding: 10px; border-radius: 6px; margin-bottom: 1rem; font-size: 0.9rem; color: #1a73e8;">
-                        <p style="margin: 0;"><strong>How to add sources:</strong></p>
-                        <ul style="margin: 5px 0 0 1.2rem; padding: 0;">
-                            <li>Use <strong>Google Calendar</strong> to sync from your other personal Google calendars.
-                            </li>
-                            <li>Use <strong>iCal URL</strong> for external calendars (like Outlook, iCloud, or public
-                                holidays).</li>
-                        </ul>
+                    <div class="info-box">
+                        <div class="info-box-icon">💡</div>
+                        <div>
+                            <strong>Add sync sources:</strong> Use <strong>Google Calendar</strong> for your personal
+                            calendars or <strong>iCal URL</strong> for external feeds (Outlook, iCloud, TeamSnap).
+                        </div>
                     </div>
 
-                    <div id="ical-container">
+                    <div id="ical-container" class="source-list">
                         <!-- Initial empty state or default row -->
                         <div class="ical-entry">
                             <input type="hidden" name="source_types" value="ical">
                             <input type="hidden" name="source_ids" value="">
 
-                            <div class="source-type-select" style="margin-bottom: 0.5rem;">
-                                <label style="font-size: 0.8rem; color: #666; margin-right: 0.5rem;">Source
-                                    Type:</label>
-                                <select onchange="changeSourceType(this)"
-                                    style="padding: 0.3rem; border-radius: 4px; border: 1px solid #ddd;">
+                            <!-- Type Selection -->
+                            <div class="source-type-group">
+                                <span class="field-label">Type</span>
+                                <select onchange="changeSourceType(this)">
                                     <option value="ical">iCal URL</option>
-                                    <option value="google">Google Calendar</option>
+                                    <option value="google">Google Cal</option>
                                 </select>
                             </div>
 
-                            <div class="input-row google-input" style="display: none;">
-                                {% if calendars %}
-                                <select name="source_ids_visible" onchange="updateHiddenId(this)"
-                                    style="width: 100%; padding: 0.6rem; border: 1px solid #dfe1e5; border-radius: 6px;">
-                                    <option value="" disabled selected>Select a Google Calendar source</option>
-                                    {% for cal in calendars %}
-                                    <option value="{{ cal.id }}">{{ cal.summary }}</option>
-                                    {% endfor %}
-                                </select>
-                                {% else %}
-                                <p style="color: #666; font-size: 0.9rem;">No Google Calendars found. <a href="/login"
-                                        style="color: var(--primary-color);">Refresh?</a></p>
-                                {% endif %}
+                            <!-- Source Input -->
+                            <div class="source-input-group">
+                                <span class="field-label">Source</span>
+
+                                <!-- Google Input -->
+                                <div class="input-row google-input hidden">
+                                    {% if calendars %}
+                                    <select name="source_ids_visible" onchange="updateHiddenId(this)">
+                                        <option value="" disabled selected>Select Calendar</option>
+                                        {% for cal in calendars %}
+                                        <option value="{{ cal.id }}">{{ cal.summary }}</option>
+                                        {% endfor %}
+                                    </select>
+                                    {% else %}
+                                    <p class="form-hint">No Google Calendars found. <a href="/login"
+                                            style="color: var(--primary-color);">Refresh?</a></p>
+                                    {% endif %}
+                                </div>
+
+                                <!-- iCal Input -->
+                                <div class="input-row ical-input">
+                                    <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
+                                        aria-label="Source Calendar URL">
+                                </div>
                             </div>
 
-                            <div class="input-row ical-input">
-                                <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
-                                    aria-label="Source Calendar URL">
+                            <!-- Prefix Input -->
+                            <div class="source-prefix-group">
+                                <span class="field-label">Prefix (Optional)</span>
+                                <input type="text" name="source_prefixes" placeholder="e.g. Work"
+                                    aria-label="Source Event Prefix">
                             </div>
 
-                            <div style="margin-top: 0.5rem; display: flex; gap: 0.5rem;">
-                                <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Work)"
-                                    aria-label="Source Event Prefix" style="flex: 1;">
+                            <!-- Actions -->
+                            <div class="source-actions">
                                 <button type="button" class="btn btn-danger" onclick="removeEntry(this)"
-                                    style="visibility: hidden;">Remove</button>
+                                    style="display: none;">
+                                    Remove
+                                </button>
                             </div>
                         </div>
                     </div>
-                    <button type="button" class="add-btn" onclick="addSourceInput()">+ Add another Source</button>
+
+                    <button type="button" class="add-btn" onclick="addSourceInput()">
+                        + Add another source
+                    </button>
                 </div>
 
-                <div class="buttons">
+                <div class="form-actions">
                     <a href="/" class="btn btn-secondary">Cancel</a>
                     <button type="submit" class="btn btn-primary">Create Sync</button>
                 </div>
@@ -122,41 +142,45 @@
 
     <!-- Template for new rows -->
     <template id="source-entry-template">
-        <div class="ical-entry" style="margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid #eee;">
+        <div class="ical-entry">
             <input type="hidden" name="source_types" value="ical">
             <input type="hidden" name="source_ids" value="">
 
-            <div class="source-type-select" style="margin-bottom: 0.5rem;">
-                <label style="font-size: 0.8rem; color: #666; margin-right: 0.5rem;">Source Type:</label>
-                <select onchange="changeSourceType(this)"
-                    style="padding: 0.3rem; border-radius: 4px; border: 1px solid #ddd;">
+            <div class="source-type-group">
+                <span class="field-label">Type</span>
+                <select onchange="changeSourceType(this)">
                     <option value="ical">iCal URL</option>
-                    <option value="google">Google Calendar</option>
+                    <option value="google">Google Cal</option>
                 </select>
             </div>
 
-            <div class="input-row google-input" style="display: none;">
-                {% if calendars %}
-                <select name="source_ids_visible" onchange="updateHiddenId(this)"
-                    style="width: 100%; padding: 0.6rem; border: 1px solid #dfe1e5; border-radius: 6px;">
-                    <option value="" disabled selected>Select a Google Calendar source</option>
-                    {% for cal in calendars %}
-                    <option value="{{ cal.id }}">{{ cal.summary }}</option>
-                    {% endfor %}
-                </select>
-                {% else %}
-                <p style="color: #666; font-size: 0.9rem;">No Google Calendars found.</p>
-                {% endif %}
+            <div class="source-input-group">
+                <span class="field-label">Source</span>
+                <div class="input-row google-input hidden">
+                    {% if calendars %}
+                    <select name="source_ids_visible" onchange="updateHiddenId(this)">
+                        <option value="" disabled selected>Select Calendar</option>
+                        {% for cal in calendars %}
+                        <option value="{{ cal.id }}">{{ cal.summary }}</option>
+                        {% endfor %}
+                    </select>
+                    {% else %}
+                    <p class="form-hint">No Google Calendars available.</p>
+                    {% endif %}
+                </div>
+
+                <div class="input-row ical-input">
+                    <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
+                        aria-label="Source Calendar URL">
+                </div>
             </div>
 
-            <div class="input-row ical-input">
-                <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
-                    aria-label="Source Calendar URL">
+            <div class="source-prefix-group">
+                <span class="field-label">Prefix (Optional)</span>
+                <input type="text" name="source_prefixes" placeholder="e.g. Work" aria-label="Source Event Prefix">
             </div>
 
-            <div style="margin-top: 0.5rem; display: flex; gap: 0.5rem;">
-                <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Work)"
-                    aria-label="Source Event Prefix" style="flex: 1;">
+            <div class="source-actions">
                 <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
             </div>
         </div>
@@ -173,18 +197,20 @@
 
         function removeEntry(btn) {
             const entry = btn.closest('.ical-entry');
-            entry.remove();
-            updateRemoveButtons();
+            if (document.querySelectorAll('.ical-entry').length > 1) {
+                entry.remove();
+                updateRemoveButtons();
+            }
         }
 
         function updateRemoveButtons() {
             const entries = document.querySelectorAll('.ical-entry');
-            entries.forEach((entry, index) => {
+            entries.forEach((entry) => {
                 const btn = entry.querySelector('.btn-danger');
                 if (entries.length === 1) {
-                    btn.style.visibility = 'hidden';
+                    btn.style.display = 'none';
                 } else {
-                    btn.style.visibility = 'visible';
+                    btn.style.display = 'inline-flex';
                 }
             });
         }
@@ -200,17 +226,15 @@
             typeInput.value = select.value;
 
             if (select.value === 'google') {
-                googleInput.style.display = 'block';
-                icalInput.style.display = 'none';
-                // Clear URL input so it submits empty
+                googleInput.classList.remove('hidden');
+                icalInput.classList.add('hidden');
                 urlInput.value = '';
-                // Enable/Disable requirements if needed
             } else {
-                googleInput.style.display = 'none';
-                icalInput.style.display = 'block';
-                // Clear ID input
+                googleInput.classList.add('hidden');
+                icalInput.classList.remove('hidden');
                 idInput.value = '';
-                entry.querySelector('select[name="source_ids_visible"]').value = "";
+                const visibleSelect = entry.querySelector('select[name="source_ids_visible"]');
+                if (visibleSelect) visibleSelect.value = "";
             }
         }
 

--- a/app/templates/create_sync.html
+++ b/app/templates/create_sync.html
@@ -50,19 +50,62 @@
 
                 <div class="form-group">
                     <label>Source Calendars</label>
-                    <div class="helper-text" style="margin-bottom: 0.5rem;">
-                        Enter the iCal URL and an optional prefix for events from this source.
+                    <div class="info-box"
+                        style="background: #e8f0fe; padding: 10px; border-radius: 6px; margin-bottom: 1rem; font-size: 0.9rem; color: #1a73e8;">
+                        <p style="margin: 0;"><strong>How to add sources:</strong></p>
+                        <ul style="margin: 5px 0 0 1.2rem; padding: 0;">
+                            <li>Use <strong>Google Calendar</strong> to sync from your other personal Google calendars.
+                            </li>
+                            <li>Use <strong>iCal URL</strong> for external calendars (like Outlook, iCloud, or public
+                                holidays).</li>
+                        </ul>
                     </div>
+
                     <div id="ical-container">
+                        <!-- Initial empty state or default row -->
                         <div class="ical-entry">
-                            <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
-                                required>
-                            <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Work)">
-                            <button type="button" class="btn btn-danger" onclick="removeEntry(this)"
-                                style="visibility: hidden;">Remove</button>
+                            <input type="hidden" name="source_types" value="ical">
+                            <input type="hidden" name="source_ids" value="">
+
+                            <div class="source-type-select" style="margin-bottom: 0.5rem;">
+                                <label style="font-size: 0.8rem; color: #666; margin-right: 0.5rem;">Source
+                                    Type:</label>
+                                <select onchange="changeSourceType(this)"
+                                    style="padding: 0.3rem; border-radius: 4px; border: 1px solid #ddd;">
+                                    <option value="ical">iCal URL</option>
+                                    <option value="google">Google Calendar</option>
+                                </select>
+                            </div>
+
+                            <div class="input-row google-input" style="display: none;">
+                                {% if calendars %}
+                                <select name="source_ids_visible" onchange="updateHiddenId(this)"
+                                    style="width: 100%; padding: 0.6rem; border: 1px solid #dfe1e5; border-radius: 6px;">
+                                    <option value="" disabled selected>Select a Google Calendar source</option>
+                                    {% for cal in calendars %}
+                                    <option value="{{ cal.id }}">{{ cal.summary }}</option>
+                                    {% endfor %}
+                                </select>
+                                {% else %}
+                                <p style="color: #666; font-size: 0.9rem;">No Google Calendars found. <a href="/login"
+                                        style="color: var(--primary-color);">Refresh?</a></p>
+                                {% endif %}
+                            </div>
+
+                            <div class="input-row ical-input">
+                                <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
+                                    aria-label="Source Calendar URL">
+                            </div>
+
+                            <div style="margin-top: 0.5rem; display: flex; gap: 0.5rem;">
+                                <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Work)"
+                                    aria-label="Source Event Prefix" style="flex: 1;">
+                                <button type="button" class="btn btn-danger" onclick="removeEntry(this)"
+                                    style="visibility: hidden;">Remove</button>
+                            </div>
                         </div>
                     </div>
-                    <button type="button" class="add-btn" onclick="addIcalInput()">+ Add another Source</button>
+                    <button type="button" class="add-btn" onclick="addSourceInput()">+ Add another Source</button>
                 </div>
 
                 <div class="buttons">
@@ -77,18 +120,50 @@
         <p>&copy; 2024 CalendarSync. All rights reserved.</p>
     </footer>
 
+    <!-- Template for new rows -->
     <template id="source-entry-template">
-        <div class="ical-entry">
-            <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
-                aria-label="Source Calendar URL" required>
-            <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Gym)" aria-label="Source Event Prefix">
-            <button type="button" class="btn btn-danger" onclick="removeEntry(this)"
-                aria-label="Remove source">Remove</button>
+        <div class="ical-entry" style="margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid #eee;">
+            <input type="hidden" name="source_types" value="ical">
+            <input type="hidden" name="source_ids" value="">
+
+            <div class="source-type-select" style="margin-bottom: 0.5rem;">
+                <label style="font-size: 0.8rem; color: #666; margin-right: 0.5rem;">Source Type:</label>
+                <select onchange="changeSourceType(this)"
+                    style="padding: 0.3rem; border-radius: 4px; border: 1px solid #ddd;">
+                    <option value="ical">iCal URL</option>
+                    <option value="google">Google Calendar</option>
+                </select>
+            </div>
+
+            <div class="input-row google-input" style="display: none;">
+                {% if calendars %}
+                <select name="source_ids_visible" onchange="updateHiddenId(this)"
+                    style="width: 100%; padding: 0.6rem; border: 1px solid #dfe1e5; border-radius: 6px;">
+                    <option value="" disabled selected>Select a Google Calendar source</option>
+                    {% for cal in calendars %}
+                    <option value="{{ cal.id }}">{{ cal.summary }}</option>
+                    {% endfor %}
+                </select>
+                {% else %}
+                <p style="color: #666; font-size: 0.9rem;">No Google Calendars found.</p>
+                {% endif %}
+            </div>
+
+            <div class="input-row ical-input">
+                <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
+                    aria-label="Source Calendar URL">
+            </div>
+
+            <div style="margin-top: 0.5rem; display: flex; gap: 0.5rem;">
+                <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Work)"
+                    aria-label="Source Event Prefix" style="flex: 1;">
+                <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
+            </div>
         </div>
     </template>
 
     <script>
-        function addIcalInput() {
+        function addSourceInput() {
             const container = document.getElementById('ical-container');
             const template = document.getElementById('source-entry-template');
             const clone = template.content.cloneNode(true);
@@ -113,6 +188,39 @@
                 }
             });
         }
+
+        function changeSourceType(select) {
+            const entry = select.closest('.ical-entry');
+            const typeInput = entry.querySelector('input[name="source_types"]');
+            const googleInput = entry.querySelector('.google-input');
+            const icalInput = entry.querySelector('.ical-input');
+            const idInput = entry.querySelector('input[name="source_ids"]');
+            const urlInput = entry.querySelector('input[name="source_urls"]');
+
+            typeInput.value = select.value;
+
+            if (select.value === 'google') {
+                googleInput.style.display = 'block';
+                icalInput.style.display = 'none';
+                // Clear URL input so it submits empty
+                urlInput.value = '';
+                // Enable/Disable requirements if needed
+            } else {
+                googleInput.style.display = 'none';
+                icalInput.style.display = 'block';
+                // Clear ID input
+                idInput.value = '';
+                entry.querySelector('select[name="source_ids_visible"]').value = "";
+            }
+        }
+
+        function updateHiddenId(select) {
+            const entry = select.closest('.ical-entry');
+            const idInput = entry.querySelector('input[name="source_ids"]');
+            idInput.value = select.value;
+        }
+
+        document.addEventListener('DOMContentLoaded', updateRemoveButtons);
     </script>
 </body>
 

--- a/app/templates/create_sync.html
+++ b/app/templates/create_sync.html
@@ -120,6 +120,7 @@
 
                             <!-- Actions -->
                             <div class="source-actions">
+                                <span class="field-label" style="visibility: hidden;">Remove</span>
                                 <button type="button" class="btn btn-danger" onclick="removeEntry(this)"
                                     style="display: none;">
                                     Remove
@@ -186,6 +187,7 @@
             </div>
 
             <div class="source-actions">
+                <span class="field-label" style="visibility: hidden;">Remove</span>
                 <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
             </div>
         </div>

--- a/app/templates/create_sync.html
+++ b/app/templates/create_sync.html
@@ -57,13 +57,18 @@
                 <!-- Sources Section -->
                 <div class="form-group">
                     <label>Source Calendars</label>
-                    <div class="info-box">
-                        <div class="info-box-icon">💡</div>
-                        <div>
-                            <strong>Add sync sources:</strong> Use <strong>Google Calendar</strong> for your personal
-                            calendars or <strong>iCal URL</strong> for external feeds (Outlook, iCloud, TeamSnap).
+                    <details class="help-box">
+                        <summary class="help-summary">Need help adding sources?</summary>
+                        <div class="help-content">
+                            <p style="margin: 0 0 0.5rem 0;"><strong>Which type should I choose?</strong></p>
+                            <ul style="padding-left: 1.2rem; margin: 0;">
+                                <li><strong>Google Calendar:</strong> Best for syncing your personal calendars (e.g.,
+                                    specific sub-calendars from your own account).</li>
+                                <li><strong>iCal URL:</strong> Use this for external links like Outlook, iCloud,
+                                    Teamsnap, or public holiday calendars.</li>
+                            </ul>
                         </div>
-                    </div>
+                    </details>
 
                     <div id="ical-container" class="source-list">
                         <!-- Initial empty state or default row -->

--- a/app/templates/edit_sync.html
+++ b/app/templates/edit_sync.html
@@ -19,16 +19,22 @@
             {% if user %}
             <span>{{ user.name }}</span>
             <img src="{{ user.picture }}" alt="Profile" style="width: 32px; height: 32px; border-radius: 50%;">
-            <a href="/logout" class="btn btn-outline">Sign Out</a>
+            <a href="/logout" class="btn btn-outline btn-sm">Sign Out</a>
             {% endif %}
         </div>
     </header>
 
     <main class="dashboard-container">
         <div class="form-card">
-            <h1>Edit Sync</h1>
+            <div class="form-header-group">
+                <h1>Edit Sync</h1>
+                <p class="form-hint">Manage your calendar synchronization settings</p>
+            </div>
+
             <form action="/edit_sync/{{ sync.id }}" method="POST">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+
+                <!-- Destination Section -->
                 <div class="form-group">
                     <label for="destination_calendar_id">Destination Calendar</label>
                     {% if calendars %}
@@ -44,121 +50,138 @@
                     <input type="text" id="destination_calendar_id" name="destination_calendar_id"
                         value="{{ sync.destination_calendar_id }}" required>
                     {% endif %}
-                    <div class="helper-text">Select the Google Calendar you want to sync events TO.</div>
+                    <div class="form-hint">Select the Google Calendar you want to sync events TO.</div>
                 </div>
 
+                <!-- Sources Section -->
                 <div class="form-group">
                     <label>Source Calendars</label>
-                    <div class="info-box"
-                        style="background: #e8f0fe; padding: 10px; border-radius: 6px; margin-bottom: 1rem; font-size: 0.9rem; color: #1a73e8;">
-                        <p style="margin: 0;"><strong>How to add sources:</strong></p>
-                        <ul style="margin: 5px 0 0 1.2rem; padding: 0;">
-                            <li>Use <strong>Google Calendar</strong> to sync from your other personal Google calendars.
-                            </li>
-                            <li>Use <strong>iCal URL</strong> for external calendars (like Outlook, iCloud, or public
-                                holidays).</li>
-                        </ul>
+                    <div class="info-box">
+                        <div class="info-box-icon">💡</div>
+                        <div>
+                            <strong>Add sync sources:</strong> Use <strong>Google Calendar</strong> for your personal
+                            calendars or <strong>iCal URL</strong> for external feeds (Outlook, iCloud, TeamSnap).
+                        </div>
                     </div>
 
-                    <div id="ical-container">
+                    <div id="ical-container" class="source-list">
                         {% for source in sync.sources %}
-                        <div class="ical-entry"
-                            style="{% if not loop.first %}margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid #eee;{% endif %}">
+                        <div class="ical-entry">
                             <input type="hidden" name="source_types" value="{{ source.type or 'ical' }}">
                             <input type="hidden" name="source_ids" value="{{ source.id or '' }}">
 
-                            <div class="source-type-select" style="margin-bottom: 0.5rem;">
-                                <label style="font-size: 0.8rem; color: #666; margin-right: 0.5rem;">Source
-                                    Type:</label>
-                                <select onchange="changeSourceType(this)"
-                                    style="padding: 0.3rem; border-radius: 4px; border: 1px solid #ddd;">
+                            <!-- Type Selection -->
+                            <div class="source-type-group">
+                                <span class="field-label">Type</span>
+                                <select onchange="changeSourceType(this)">
                                     <option value="ical" {% if (source.type or 'ical' )=='ical' %}selected{% endif %}>
                                         iCal URL</option>
-                                    <option value="google" {% if source.type=='google' %}selected{% endif %}>Google
-                                        Calendar</option>
+                                    <option value="google" {% if source.type=='google' %}selected{% endif %}>Google Cal
+                                    </option>
                                 </select>
                             </div>
 
-                            <div class="input-row google-input"
-                                style="display: {% if source.type == 'google' %}block{% else %}none{% endif %};">
-                                {% if calendars %}
-                                <select name="source_ids_visible" onchange="updateHiddenId(this)"
-                                    style="width: 100%; padding: 0.6rem; border: 1px solid #dfe1e5; border-radius: 6px;">
-                                    <option value="" disabled {% if not source.id %}selected{% endif %}>Select a Google
-                                        Calendar source</option>
-                                    {% for cal in calendars %}
-                                    <option value="{{ cal.id }}" {% if cal.id==source.id %}selected{% endif %}>{{
-                                        cal.summary }}</option>
-                                    {% endfor %}
-                                </select>
-                                {% else %}
-                                <p style="color: #666; font-size: 0.9rem;">No Google Calendars available.</p>
-                                {% endif %}
+                            <!-- Source Input (Google/URL) -->
+                            <div class="source-input-group">
+                                <span class="field-label">Source</span>
+
+                                <!-- Google Input -->
+                                <div class="input-row google-input {% if source.type != 'google' %}hidden{% endif %}">
+                                    {% if calendars %}
+                                    <select name="source_ids_visible" onchange="updateHiddenId(this)">
+                                        <option value="" disabled {% if not source.id %}selected{% endif %}>Select
+                                            Calendar</option>
+                                        {% for cal in calendars %}
+                                        <option value="{{ cal.id }}" {% if cal.id==source.id %}selected{% endif %}>{{
+                                            cal.summary }}</option>
+                                        {% endfor %}
+                                    </select>
+                                    {% else %}
+                                    <p class="form-hint">No Google Calendars available.</p>
+                                    {% endif %}
+                                </div>
+
+                                <!-- iCal Input -->
+                                <div
+                                    class="input-row ical-input {% if (source.type or 'ical') != 'ical' %}hidden{% endif %}">
+                                    <input type="text" name="source_urls" value="{{ source.url }}"
+                                        placeholder="https://example.com/calendar.ics" aria-label="Source Calendar URL">
+                                </div>
                             </div>
 
-                            <div class="input-row ical-input"
-                                style="display: {% if (source.type or 'ical') == 'ical' %}block{% else %}none{% endif %};">
-                                <input type="text" name="source_urls" value="{{ source.url }}"
-                                    placeholder="https://example.com/calendar.ics" aria-label="Source Calendar URL">
-                            </div>
-
-                            <div style="margin-top: 0.5rem; display: flex; gap: 0.5rem;">
+                            <!-- Prefix Input -->
+                            <div class="source-prefix-group">
+                                <span class="field-label">Prefix (Optional)</span>
                                 <input type="text" name="source_prefixes" value="{{ source.prefix or '' }}"
-                                    placeholder="Prefix (e.g. Work)" aria-label="Source Event Prefix" style="flex: 1;">
-                                <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
+                                    placeholder="e.g. Work" aria-label="Source Event Prefix">
+                            </div>
+
+                            <!-- Actions -->
+                            <div class="source-actions">
+                                <button type="button" class="btn btn-danger" onclick="removeEntry(this)"
+                                    aria-label="Remove Source">
+                                    Remove
+                                </button>
                             </div>
                         </div>
                         {% endfor %}
 
                         {% if not sync.sources %}
-                        <!-- Fallback empty state -->
+                        <!-- Fallback empty state with one row -->
                         <div class="ical-entry">
                             <input type="hidden" name="source_types" value="ical">
                             <input type="hidden" name="source_ids" value="">
 
-                            <div class="source-type-select" style="margin-bottom: 0.5rem;">
-                                <label style="font-size: 0.8rem; color: #666; margin-right: 0.5rem;">Source
-                                    Type:</label>
-                                <select onchange="changeSourceType(this)"
-                                    style="padding: 0.3rem; border-radius: 4px; border: 1px solid #ddd;">
+                            <div class="source-type-group">
+                                <span class="field-label">Type</span>
+                                <select onchange="changeSourceType(this)">
                                     <option value="ical">iCal URL</option>
-                                    <option value="google">Google Calendar</option>
+                                    <option value="google">Google Cal</option>
                                 </select>
                             </div>
 
-                            <div class="input-row google-input" style="display: none;">
-                                {% if calendars %}
-                                <select name="source_ids_visible" onchange="updateHiddenId(this)"
-                                    style="width: 100%; padding: 0.6rem; border: 1px solid #dfe1e5; border-radius: 6px;">
-                                    <option value="" disabled selected>Select a Google Calendar source</option>
-                                    {% for cal in calendars %}
-                                    <option value="{{ cal.id }}">{{ cal.summary }}</option>
-                                    {% endfor %}
-                                </select>
-                                {% else %}
-                                <p style="color: #666; font-size: 0.9rem;">No Google Calendars available.</p>
-                                {% endif %}
+                            <div class="source-input-group">
+                                <span class="field-label">Source</span>
+                                <div class="input-row google-input hidden">
+                                    {% if calendars %}
+                                    <select name="source_ids_visible" onchange="updateHiddenId(this)">
+                                        <option value="" disabled selected>Select Calendar</option>
+                                        {% for cal in calendars %}
+                                        <option value="{{ cal.id }}">{{ cal.summary }}</option>
+                                        {% endfor %}
+                                    </select>
+                                    {% else %}
+                                    <p class="form-hint">No Google Calendars available.</p>
+                                    {% endif %}
+                                </div>
+
+                                <div class="input-row ical-input">
+                                    <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
+                                        aria-label="Source Calendar URL">
+                                </div>
                             </div>
 
-                            <div class="input-row ical-input">
-                                <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
-                                    aria-label="Source Calendar URL">
+                            <div class="source-prefix-group">
+                                <span class="field-label">Prefix (Optional)</span>
+                                <input type="text" name="source_prefixes" placeholder="e.g. Work"
+                                    aria-label="Source Event Prefix">
                             </div>
 
-                            <div style="margin-top: 0.5rem; display: flex; gap: 0.5rem;">
-                                <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Work)"
-                                    aria-label="Source Event Prefix" style="flex: 1;">
+                            <div class="source-actions">
                                 <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
                             </div>
                         </div>
                         {% endif %}
                     </div>
-                    <button type="button" class="add-btn" onclick="addSourceInput()">+ Add another Source</button>
+
+                    <button type="button" class="add-btn" onclick="addSourceInput()">
+                        + Add another source
+                    </button>
                 </div>
 
-                <div class="buttons">
+                <div class="form-actions">
                     <a href="/" class="btn btn-secondary">Cancel</a>
-                    <button type="submit" class="btn btn-primary">Update Sync</button>
+                    <button type="submit" class="btn btn-primary">Save Changes</button>
                 </div>
             </form>
         </div>
@@ -169,41 +192,45 @@
     </footer>
 
     <template id="source-entry-template">
-        <div class="ical-entry" style="margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid #eee;">
+        <div class="ical-entry">
             <input type="hidden" name="source_types" value="ical">
             <input type="hidden" name="source_ids" value="">
 
-            <div class="source-type-select" style="margin-bottom: 0.5rem;">
-                <label style="font-size: 0.8rem; color: #666; margin-right: 0.5rem;">Source Type:</label>
-                <select onchange="changeSourceType(this)"
-                    style="padding: 0.3rem; border-radius: 4px; border: 1px solid #ddd;">
+            <div class="source-type-group">
+                <span class="field-label">Type</span>
+                <select onchange="changeSourceType(this)">
                     <option value="ical">iCal URL</option>
-                    <option value="google">Google Calendar</option>
+                    <option value="google">Google Cal</option>
                 </select>
             </div>
 
-            <div class="input-row google-input" style="display: none;">
-                {% if calendars %}
-                <select name="source_ids_visible" onchange="updateHiddenId(this)"
-                    style="width: 100%; padding: 0.6rem; border: 1px solid #dfe1e5; border-radius: 6px;">
-                    <option value="" disabled selected>Select a Google Calendar source</option>
-                    {% for cal in calendars %}
-                    <option value="{{ cal.id }}">{{ cal.summary }}</option>
-                    {% endfor %}
-                </select>
-                {% else %}
-                <p style="color: #666; font-size: 0.9rem;">No Google Calendars found.</p>
-                {% endif %}
+            <div class="source-input-group">
+                <span class="field-label">Source</span>
+                <div class="input-row google-input hidden">
+                    {% if calendars %}
+                    <select name="source_ids_visible" onchange="updateHiddenId(this)">
+                        <option value="" disabled selected>Select Calendar</option>
+                        {% for cal in calendars %}
+                        <option value="{{ cal.id }}">{{ cal.summary }}</option>
+                        {% endfor %}
+                    </select>
+                    {% else %}
+                    <p class="form-hint">No Google Calendars available.</p>
+                    {% endif %}
+                </div>
+
+                <div class="input-row ical-input">
+                    <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
+                        aria-label="Source Calendar URL">
+                </div>
             </div>
 
-            <div class="input-row ical-input">
-                <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
-                    aria-label="Source Calendar URL">
+            <div class="source-prefix-group">
+                <span class="field-label">Prefix (Optional)</span>
+                <input type="text" name="source_prefixes" placeholder="e.g. Work" aria-label="Source Event Prefix">
             </div>
 
-            <div style="margin-top: 0.5rem; display: flex; gap: 0.5rem;">
-                <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Work)"
-                    aria-label="Source Event Prefix" style="flex: 1;">
+            <div class="source-actions">
                 <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
             </div>
         </div>
@@ -220,18 +247,20 @@
 
         function removeEntry(btn) {
             const entry = btn.closest('.ical-entry');
-            entry.remove();
-            updateRemoveButtons();
+            if (document.querySelectorAll('.ical-entry').length > 1) {
+                entry.remove();
+                updateRemoveButtons();
+            }
         }
 
         function updateRemoveButtons() {
             const entries = document.querySelectorAll('.ical-entry');
-            entries.forEach((entry, index) => {
+            entries.forEach((entry) => {
                 const btn = entry.querySelector('.btn-danger');
                 if (entries.length === 1) {
-                    btn.style.visibility = 'hidden';
+                    btn.style.display = 'none'; // Changed from visibility: hidden to display: none for better layout
                 } else {
-                    btn.style.visibility = 'visible';
+                    btn.style.display = 'inline-flex';
                 }
             });
         }
@@ -247,12 +276,12 @@
             typeInput.value = select.value;
 
             if (select.value === 'google') {
-                googleInput.style.display = 'block';
-                icalInput.style.display = 'none';
+                googleInput.classList.remove('hidden');
+                icalInput.classList.add('hidden');
                 urlInput.value = '';
             } else {
-                googleInput.style.display = 'none';
-                icalInput.style.display = 'block';
+                googleInput.classList.add('hidden');
+                icalInput.classList.remove('hidden');
                 idInput.value = '';
                 const visibleSelect = entry.querySelector('select[name="source_ids_visible"]');
                 if (visibleSelect) visibleSelect.value = "";

--- a/app/templates/edit_sync.html
+++ b/app/templates/edit_sync.html
@@ -123,6 +123,7 @@
 
                             <!-- Actions -->
                             <div class="source-actions">
+                                <span class="field-label" style="visibility: hidden;">Remove</span>
                                 <button type="button" class="btn btn-danger" onclick="removeEntry(this)"
                                     aria-label="Remove Source">
                                     Remove
@@ -173,6 +174,7 @@
                             </div>
 
                             <div class="source-actions">
+                                <span class="field-label" style="visibility: hidden;">Remove</span>
                                 <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
                             </div>
                         </div>
@@ -236,6 +238,7 @@
             </div>
 
             <div class="source-actions">
+                <span class="field-label" style="visibility: hidden;">Remove</span>
                 <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
             </div>
         </div>

--- a/app/templates/edit_sync.html
+++ b/app/templates/edit_sync.html
@@ -49,34 +49,111 @@
 
                 <div class="form-group">
                     <label>Source Calendars</label>
-                    <div class="helper-text" style="margin-bottom: 0.5rem;">
-                        Enter the iCal URL and an optional prefix for events from this source.
+                    <div class="info-box"
+                        style="background: #e8f0fe; padding: 10px; border-radius: 6px; margin-bottom: 1rem; font-size: 0.9rem; color: #1a73e8;">
+                        <p style="margin: 0;"><strong>How to add sources:</strong></p>
+                        <ul style="margin: 5px 0 0 1.2rem; padding: 0;">
+                            <li>Use <strong>Google Calendar</strong> to sync from your other personal Google calendars.
+                            </li>
+                            <li>Use <strong>iCal URL</strong> for external calendars (like Outlook, iCloud, or public
+                                holidays).</li>
+                        </ul>
                     </div>
+
                     <div id="ical-container">
                         {% for source in sync.sources %}
-                        <div class="ical-entry">
-                            <input type="text" name="source_urls" value="{{ source.url }}"
-                                placeholder="https://example.com/calendar.ics" aria-label="Source Calendar URL"
-                                required>
-                            <input type="text" name="source_prefixes" value="{{ source.prefix or '' }}"
-                                placeholder="Prefix (e.g. Work)" aria-label="Source Event Prefix">
-                            <button type="button" class="btn btn-danger" onclick="removeEntry(this)"
-                                aria-label="Remove source">Remove</button>
+                        <div class="ical-entry"
+                            style="{% if not loop.first %}margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid #eee;{% endif %}">
+                            <input type="hidden" name="source_types" value="{{ source.type or 'ical' }}">
+                            <input type="hidden" name="source_ids" value="{{ source.id or '' }}">
+
+                            <div class="source-type-select" style="margin-bottom: 0.5rem;">
+                                <label style="font-size: 0.8rem; color: #666; margin-right: 0.5rem;">Source
+                                    Type:</label>
+                                <select onchange="changeSourceType(this)"
+                                    style="padding: 0.3rem; border-radius: 4px; border: 1px solid #ddd;">
+                                    <option value="ical" {% if (source.type or 'ical' )=='ical' %}selected{% endif %}>
+                                        iCal URL</option>
+                                    <option value="google" {% if source.type=='google' %}selected{% endif %}>Google
+                                        Calendar</option>
+                                </select>
+                            </div>
+
+                            <div class="input-row google-input"
+                                style="display: {% if source.type == 'google' %}block{% else %}none{% endif %};">
+                                {% if calendars %}
+                                <select name="source_ids_visible" onchange="updateHiddenId(this)"
+                                    style="width: 100%; padding: 0.6rem; border: 1px solid #dfe1e5; border-radius: 6px;">
+                                    <option value="" disabled {% if not source.id %}selected{% endif %}>Select a Google
+                                        Calendar source</option>
+                                    {% for cal in calendars %}
+                                    <option value="{{ cal.id }}" {% if cal.id==source.id %}selected{% endif %}>{{
+                                        cal.summary }}</option>
+                                    {% endfor %}
+                                </select>
+                                {% else %}
+                                <p style="color: #666; font-size: 0.9rem;">No Google Calendars available.</p>
+                                {% endif %}
+                            </div>
+
+                            <div class="input-row ical-input"
+                                style="display: {% if (source.type or 'ical') == 'ical' %}block{% else %}none{% endif %};">
+                                <input type="text" name="source_urls" value="{{ source.url }}"
+                                    placeholder="https://example.com/calendar.ics" aria-label="Source Calendar URL">
+                            </div>
+
+                            <div style="margin-top: 0.5rem; display: flex; gap: 0.5rem;">
+                                <input type="text" name="source_prefixes" value="{{ source.prefix or '' }}"
+                                    placeholder="Prefix (e.g. Work)" aria-label="Source Event Prefix" style="flex: 1;">
+                                <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
+                            </div>
                         </div>
                         {% endfor %}
 
-                        {% if not sources %}
+                        {% if not sync.sources %}
+                        <!-- Fallback empty state -->
                         <div class="ical-entry">
-                            <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
-                                aria-label="Source Calendar URL" required>
-                            <input type="text" name="source_prefixes" placeholder="Prefix (e.g. School)"
-                                aria-label="Source Event Prefix">
-                            <button type="button" class="btn btn-danger" onclick="removeEntry(this)"
-                                style="visibility: hidden;" aria-label="Remove source">Remove</button>
+                            <input type="hidden" name="source_types" value="ical">
+                            <input type="hidden" name="source_ids" value="">
+
+                            <div class="source-type-select" style="margin-bottom: 0.5rem;">
+                                <label style="font-size: 0.8rem; color: #666; margin-right: 0.5rem;">Source
+                                    Type:</label>
+                                <select onchange="changeSourceType(this)"
+                                    style="padding: 0.3rem; border-radius: 4px; border: 1px solid #ddd;">
+                                    <option value="ical">iCal URL</option>
+                                    <option value="google">Google Calendar</option>
+                                </select>
+                            </div>
+
+                            <div class="input-row google-input" style="display: none;">
+                                {% if calendars %}
+                                <select name="source_ids_visible" onchange="updateHiddenId(this)"
+                                    style="width: 100%; padding: 0.6rem; border: 1px solid #dfe1e5; border-radius: 6px;">
+                                    <option value="" disabled selected>Select a Google Calendar source</option>
+                                    {% for cal in calendars %}
+                                    <option value="{{ cal.id }}">{{ cal.summary }}</option>
+                                    {% endfor %}
+                                </select>
+                                {% else %}
+                                <p style="color: #666; font-size: 0.9rem;">No Google Calendars available.</p>
+                                {% endif %}
+                            </div>
+
+                            <div class="input-row ical-input">
+                                <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
+                                    aria-label="Source Calendar URL">
+                            </div>
+
+                            <div style="margin-top: 0.5rem; display: flex; gap: 0.5rem;">
+                                <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Work)"
+                                    aria-label="Source Event Prefix" style="flex: 1;">
+                                <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
+                            </div>
                         </div>
                         {% endif %}
                     </div>
-                    <button type="button" class="add-btn" onclick="addIcalInput()">+ Add another Source</button>
+                    <button type="button" class="add-btn" onclick="addSourceInput()">+ Add another Source</button>
                 </div>
 
                 <div class="buttons">
@@ -92,17 +169,48 @@
     </footer>
 
     <template id="source-entry-template">
-        <div class="ical-entry">
-            <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
-                aria-label="Source Calendar URL" required>
-            <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Gym)" aria-label="Source Event Prefix">
-            <button type="button" class="btn btn-danger" onclick="removeEntry(this)"
-                aria-label="Remove source">Remove</button>
+        <div class="ical-entry" style="margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid #eee;">
+            <input type="hidden" name="source_types" value="ical">
+            <input type="hidden" name="source_ids" value="">
+
+            <div class="source-type-select" style="margin-bottom: 0.5rem;">
+                <label style="font-size: 0.8rem; color: #666; margin-right: 0.5rem;">Source Type:</label>
+                <select onchange="changeSourceType(this)"
+                    style="padding: 0.3rem; border-radius: 4px; border: 1px solid #ddd;">
+                    <option value="ical">iCal URL</option>
+                    <option value="google">Google Calendar</option>
+                </select>
+            </div>
+
+            <div class="input-row google-input" style="display: none;">
+                {% if calendars %}
+                <select name="source_ids_visible" onchange="updateHiddenId(this)"
+                    style="width: 100%; padding: 0.6rem; border: 1px solid #dfe1e5; border-radius: 6px;">
+                    <option value="" disabled selected>Select a Google Calendar source</option>
+                    {% for cal in calendars %}
+                    <option value="{{ cal.id }}">{{ cal.summary }}</option>
+                    {% endfor %}
+                </select>
+                {% else %}
+                <p style="color: #666; font-size: 0.9rem;">No Google Calendars found.</p>
+                {% endif %}
+            </div>
+
+            <div class="input-row ical-input">
+                <input type="text" name="source_urls" placeholder="https://example.com/calendar.ics"
+                    aria-label="Source Calendar URL">
+            </div>
+
+            <div style="margin-top: 0.5rem; display: flex; gap: 0.5rem;">
+                <input type="text" name="source_prefixes" placeholder="Prefix (e.g. Work)"
+                    aria-label="Source Event Prefix" style="flex: 1;">
+                <button type="button" class="btn btn-danger" onclick="removeEntry(this)">Remove</button>
+            </div>
         </div>
     </template>
 
     <script>
-        function addIcalInput() {
+        function addSourceInput() {
             const container = document.getElementById('ical-container');
             const template = document.getElementById('source-entry-template');
             const clone = template.content.cloneNode(true);
@@ -128,7 +236,35 @@
             });
         }
 
-        // Initial setup for remove buttons
+        function changeSourceType(select) {
+            const entry = select.closest('.ical-entry');
+            const typeInput = entry.querySelector('input[name="source_types"]');
+            const googleInput = entry.querySelector('.google-input');
+            const icalInput = entry.querySelector('.ical-input');
+            const idInput = entry.querySelector('input[name="source_ids"]');
+            const urlInput = entry.querySelector('input[name="source_urls"]');
+
+            typeInput.value = select.value;
+
+            if (select.value === 'google') {
+                googleInput.style.display = 'block';
+                icalInput.style.display = 'none';
+                urlInput.value = '';
+            } else {
+                googleInput.style.display = 'none';
+                icalInput.style.display = 'block';
+                idInput.value = '';
+                const visibleSelect = entry.querySelector('select[name="source_ids_visible"]');
+                if (visibleSelect) visibleSelect.value = "";
+            }
+        }
+
+        function updateHiddenId(select) {
+            const entry = select.closest('.ical-entry');
+            const idInput = entry.querySelector('input[name="source_ids"]');
+            idInput.value = select.value;
+        }
+
         document.addEventListener('DOMContentLoaded', updateRemoveButtons);
     </script>
 </body>

--- a/app/templates/edit_sync.html
+++ b/app/templates/edit_sync.html
@@ -56,13 +56,18 @@
                 <!-- Sources Section -->
                 <div class="form-group">
                     <label>Source Calendars</label>
-                    <div class="info-box">
-                        <div class="info-box-icon">💡</div>
-                        <div>
-                            <strong>Add sync sources:</strong> Use <strong>Google Calendar</strong> for your personal
-                            calendars or <strong>iCal URL</strong> for external feeds (Outlook, iCloud, TeamSnap).
+                    <details class="help-box">
+                        <summary class="help-summary">Need help adding sources?</summary>
+                        <div class="help-content">
+                            <p style="margin: 0 0 0.5rem 0;"><strong>Which type should I choose?</strong></p>
+                            <ul style="padding-left: 1.2rem; margin: 0;">
+                                <li><strong>Google Calendar:</strong> Best for syncing your personal calendars (e.g.,
+                                    specific sub-calendars from your own account).</li>
+                                <li><strong>iCal URL:</strong> Use this for external links like Outlook, iCloud,
+                                    Teamsnap, or public holiday calendars.</li>
+                            </ul>
                         </div>
-                    </div>
+                    </details>
 
                     <div id="ical-container" class="source-list">
                         {% for source in sync.sources %}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -187,10 +187,16 @@ resource "google_cloud_run_service" "default" {
 
 # Domain Mapping
 # Firebase Hosting Custom Domain
+data "google_firebase_hosting_site" "default" {
+  provider = google-beta
+  project  = var.project_id
+  site_id  = var.project_id # Assuming default site is used
+}
+
 resource "google_firebase_hosting_custom_domain" "default" {
   provider      = google-beta
   project       = var.project_id
-  site_id       = var.project_id
+  site_id       = data.google_firebase_hosting_site.default.site_id
   custom_domain = var.domain_name
 
   depends_on = [google_firebase_web_app.default]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -187,16 +187,10 @@ resource "google_cloud_run_service" "default" {
 
 # Domain Mapping
 # Firebase Hosting Custom Domain
-data "google_firebase_hosting_site" "default" {
-  provider = google-beta
-  project  = var.project_id
-  site_id  = var.project_id # Assuming default site is used
-}
-
 resource "google_firebase_hosting_custom_domain" "default" {
   provider      = google-beta
   project       = var.project_id
-  site_id       = data.google_firebase_hosting_site.default.site_id
+  site_id       = var.project_id
   custom_domain = var.domain_name
 
   depends_on = [google_firebase_web_app.default]

--- a/tests/test_auto_sync_trigger.py
+++ b/tests/test_auto_sync_trigger.py
@@ -1,0 +1,78 @@
+
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+# Add app to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app.app import app
+
+class TestAutoSync(unittest.TestCase):
+    def setUp(self):
+        self.app = app.test_client()
+        self.app.testing = True
+
+    @patch('app.app.sync_calendar_logic')
+    @patch('app.app.firestore')
+    @patch('app.app.fetch_user_calendars')
+    def test_create_sync_triggers_sync(self, mock_fetch_cals, mock_firestore, mock_sync_logic):
+        """Test POST /create_sync triggers auto-sync."""
+        
+        # Mock Session
+        with self.app.session_transaction() as sess:
+            sess['user'] = {'uid': 'test_user', 'name': 'Test User'}
+            sess['calendars'] = [{'id': 'dest_cal', 'summary': 'Destination'}]
+            sess['csrf_token'] = 'token'
+
+        # Mock Firestore
+        mock_db = MagicMock()
+        mock_firestore.client.return_value = mock_db
+        mock_sync_ref = MagicMock()
+        mock_sync_ref.id = 'new_sync_id'
+        mock_db.collection.return_value.document.return_value = mock_sync_ref
+
+        # Submit Form
+        response = self.app.post('/create_sync', data={
+            'destination_calendar_id': 'dest_cal',
+            'source_urls': ['http://example.com/ics'],
+            'csrf_token': 'token'
+        })
+        
+        self.assertEqual(response.status_code, 302)
+        # Verify sync_calendar_logic was called with new sync ID
+        mock_sync_logic.assert_called_once_with('new_sync_id')
+
+    @patch('app.app.sync_calendar_logic')
+    @patch('app.app.firestore')
+    def test_edit_sync_triggers_sync(self, mock_firestore, mock_sync_logic):
+        """Test POST /edit_sync triggers auto-sync."""
+        
+        with self.app.session_transaction() as sess:
+            sess['user'] = {'uid': 'test_user'}
+            sess['calendars'] = [{'id': 'dest_cal', 'summary': 'Destination'}]
+            sess['csrf_token'] = 'token'
+
+        mock_db = MagicMock()
+        mock_firestore.client.return_value = mock_db
+        mock_sync_ref = MagicMock()
+        mock_sync_ref.id = 'existing_sync_id'
+        mock_db.collection.return_value.document.return_value = mock_sync_ref
+        
+        # We need verify_owner to pass, usually handled via getting the doc
+        mock_doc = MagicMock()
+        mock_doc.exists = True
+        mock_doc.to_dict.return_value = {'user_id': 'test_user'}
+        mock_sync_ref.get.return_value = mock_doc
+
+        response = self.app.post('/edit_sync/existing_sync_id', data={
+            'destination_calendar_id': 'dest_cal',
+            'source_urls': ['http://example.com/new_ics'],
+            'csrf_token': 'token'
+        })
+
+        self.assertEqual(response.status_code, 302)
+        mock_sync_logic.assert_called_once_with('existing_sync_id')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_auto_sync_trigger.py
+++ b/tests/test_auto_sync_trigger.py
@@ -1,78 +1,88 @@
-
 import unittest
 from unittest.mock import patch, MagicMock
 import sys
 import os
 
+
 # Add app to path
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from app.app import app
+
 
 class TestAutoSync(unittest.TestCase):
     def setUp(self):
         self.app = app.test_client()
         self.app.testing = True
 
-    @patch('app.app.sync_calendar_logic')
-    @patch('app.app.firestore')
-    @patch('app.app.fetch_user_calendars')
-    def test_create_sync_triggers_sync(self, mock_fetch_cals, mock_firestore, mock_sync_logic):
+    @patch("app.app.sync_calendar_logic")
+    @patch("app.app.firestore")
+    @patch("app.app.fetch_user_calendars")
+    def test_create_sync_triggers_sync(
+        self, mock_fetch_cals, mock_firestore, mock_sync_logic
+    ):
         """Test POST /create_sync triggers auto-sync."""
-        
+
         # Mock Session
         with self.app.session_transaction() as sess:
-            sess['user'] = {'uid': 'test_user', 'name': 'Test User'}
-            sess['calendars'] = [{'id': 'dest_cal', 'summary': 'Destination'}]
-            sess['csrf_token'] = 'token'
+            sess["user"] = {"uid": "test_user", "name": "Test User"}
+            sess["calendars"] = [{"id": "dest_cal", "summary": "Destination"}]
+            sess["csrf_token"] = "token"
 
         # Mock Firestore
         mock_db = MagicMock()
         mock_firestore.client.return_value = mock_db
         mock_sync_ref = MagicMock()
-        mock_sync_ref.id = 'new_sync_id'
+        mock_sync_ref.id = "new_sync_id"
         mock_db.collection.return_value.document.return_value = mock_sync_ref
 
         # Submit Form
-        response = self.app.post('/create_sync', data={
-            'destination_calendar_id': 'dest_cal',
-            'source_urls': ['http://example.com/ics'],
-            'csrf_token': 'token'
-        })
-        
+        response = self.app.post(
+            "/create_sync",
+            data={
+                "destination_calendar_id": "dest_cal",
+                "source_urls": ["http://example.com/ics"],
+                "csrf_token": "token",
+            },
+        )
+
         self.assertEqual(response.status_code, 302)
         # Verify sync_calendar_logic was called with new sync ID
-        mock_sync_logic.assert_called_once_with('new_sync_id')
+        mock_sync_logic.assert_called_once_with("new_sync_id")
 
-    @patch('app.app.sync_calendar_logic')
-    @patch('app.app.firestore')
+    @patch("app.app.sync_calendar_logic")
+    @patch("app.app.firestore")
     def test_edit_sync_triggers_sync(self, mock_firestore, mock_sync_logic):
         """Test POST /edit_sync triggers auto-sync."""
-        
+
         with self.app.session_transaction() as sess:
-            sess['user'] = {'uid': 'test_user'}
-            sess['calendars'] = [{'id': 'dest_cal', 'summary': 'Destination'}]
-            sess['csrf_token'] = 'token'
+            sess["user"] = {"uid": "test_user"}
+            sess["calendars"] = [{"id": "dest_cal", "summary": "Destination"}]
+            sess["csrf_token"] = "token"
 
         mock_db = MagicMock()
         mock_firestore.client.return_value = mock_db
         mock_sync_ref = MagicMock()
-        mock_sync_ref.id = 'existing_sync_id'
+        mock_sync_ref.id = "existing_sync_id"
         mock_db.collection.return_value.document.return_value = mock_sync_ref
-        
+
         # We need verify_owner to pass, usually handled via getting the doc
         mock_doc = MagicMock()
         mock_doc.exists = True
-        mock_doc.to_dict.return_value = {'user_id': 'test_user'}
+        mock_doc.to_dict.return_value = {"user_id": "test_user"}
         mock_sync_ref.get.return_value = mock_doc
 
-        response = self.app.post('/edit_sync/existing_sync_id', data={
-            'destination_calendar_id': 'dest_cal',
-            'source_urls': ['http://example.com/new_ics'],
-            'csrf_token': 'token'
-        })
+        response = self.app.post(
+            "/edit_sync/existing_sync_id",
+            data={
+                "destination_calendar_id": "dest_cal",
+                "source_urls": ["http://example.com/new_ics"],
+                "csrf_token": "token",
+            },
+        )
 
         self.assertEqual(response.status_code, 302)
-        mock_sync_logic.assert_called_once_with('existing_sync_id')
+        mock_sync_logic.assert_called_once_with("existing_sync_id")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description
This PR implements the ability for users to select one of their personal Google Calendars as a source for synchronization, in addition to the existing iCal URL support.

## Changes
- **Frontend**: Updated `Create Sync` and `Edit Sync` pages to allow selecting a Google Calendar from a dropdown or entering an iCal URL.
- **Backend**: Implemented logic to fetch events directly from the Google Calendar API for these sources, converting them to the internal format used by the sync engine.
- **Fix**: Renamed session cookie to `__session` to comply with Firebase Hosting requirements (fixes login loop in dev).

## Verification
- Verified manually using a custom test script `tests/verify_google_source.py` (since deleted).
- Verified cookie config using `tests/verify_cookie_config.py` (since deleted).
- Ran existing unit tests.
