### PR TITLE
chore: Enable Dependabot deployments

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -19,6 +19,5 @@ jobs:
       service_name: "calendarsync-dev"
       region: "us-central1"
       custom_url: "https://calendarsync-dev.billnapier.com"
-    secrets:
-      wif_provider: ${{ secrets.DEV_GCP_WIF_PROVIDER }}
-      wif_service_account: ${{ secrets.DEV_GCP_WIF_SA_EMAIL }}
+      wif_provider: "projects/61852959082/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+      wif_service_account: "github-actions-sa@calendarsync-napier-dev.iam.gserviceaccount.com"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -22,6 +22,5 @@ jobs:
       service_name: "python-cloudrun-app"
       region: "us-central1"
       custom_url: "https://calendarsync.billnapier.com"
-    secrets:
-      wif_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-      wif_service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+      wif_provider: "projects/179450231286/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+      wif_service_account: "github-actions-sa@calendarsync-napier.iam.gserviceaccount.com"

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -23,13 +23,15 @@ on:
         required: false
         type: string
         description: "Custom URL to checking smoke test against"
-    secrets:
       wif_provider:
         required: true
+        type: string
         description: "Workload Identity Provider"
       wif_service_account:
         required: true
+        type: string
         description: "Workload Identity Service Account"
+
 
 jobs:
   deploy:
@@ -47,8 +49,8 @@ jobs:
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed' # ratchet:google-github-actions/auth@v2
         with:
-          workload_identity_provider: '${{ secrets.wif_provider }}'
-          service_account: '${{ secrets.wif_service_account }}'
+          workload_identity_provider: '${{ inputs.wif_provider }}'
+          service_account: '${{ inputs.wif_service_account }}'
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # ratchet:google-github-actions/setup-gcloud@v2


### PR DESCRIPTION
Refactors deployment workflows to remove dependency on GitHub Secrets for Workload Identity Federation (WIF) configuration. This allows Dependabot and other forks to run deployment workflows (or at least pass the initial config steps) without requiring secret access.