### PR TITLE
⚡ Bolt: Eliminate redundant source fetches during sync creation/update

### DIFF
--- a/app/sync/logic.py
+++ b/app/sync/logic.py
@@ -120,11 +120,12 @@ def get_calendar_name_from_ical(url):
     return url
 
 
-def resolve_source_names(sources, calendars):
+def resolve_source_names(sources, calendars, fetch_remote=True):
     """
     Efficiently resolve friendly names for sources.
     - sources: list of source dicts
     - calendars: list of Google Calendar dicts (id, summary)
+    - fetch_remote: if False, skip fetching names for iCal URLs (saves time)
     """
     source_names = {}
     cal_map = {cal["id"]: cal["summary"] for cal in calendars} if calendars else {}
@@ -137,7 +138,7 @@ def resolve_source_names(sources, calendars):
             if source.get("type") == "google":
                 # Use map for O(1) lookup
                 source_names[url] = cal_map.get(source["id"], source["id"])
-            else:
+            elif fetch_remote:
                 ical_sources.append(url)
 
         if ical_sources:


### PR DESCRIPTION
💡 **What:**
- Modified `app/sync/logic.py`: Updated `resolve_source_names` to accept a `fetch_remote` boolean argument. When `False`, it skips the HTTP requests to fetch iCal names but still resolves Google Calendar names from the provided cache.
- Modified `app/main/routes.py`: Updated `create_sync` and `edit_sync` handlers to call `resolve_source_names` with `fetch_remote=False`.

🎯 **Why:**
- Previously, `create_sync` and `edit_sync` would fetch iCal feeds to get the calendar name (`X-WR-CALNAME`). Immediately after, `sync_calendar_logic` would run and fetch the same iCal feeds *again* to parse events.
- This redundant fetching doubled the network I/O and latency for iCal sources during these operations.

📊 **Impact:**
- Reduces HTTP requests by N (where N is the number of iCal sources) during sync creation and editing.
- Improves user-perceived performance (faster form submission response).
- Ensures Google Calendar names are still resolved immediately (no regression for Google sources).

🔬 **Measurement:**
- Verified with unit tests that `sync_calendar_logic` still functions correctly.
- Verified logic ensures `source_names` are eventually consistent.

---
*PR created automatically by Jules for task [11134600063902816035](https://jules.google.com/task/11134600063902816035) started by @billnapier*