### PR TITLE
🛡️ Sentinel: Fix CSP violation in alert dismissal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** User input for external URLs was not validated at configuration time, only at usage time.
 **Learning:** While runtime protection (SSRF checks in `safe_requests_get`) prevents exploitation, allowing invalid data to be stored degrades data integrity and user experience.
 **Prevention:** Validate inputs (like URLs) at the boundary (API/Form submission) to fail fast, even if runtime checks are also present (defense in depth).
+
+## 2025-01-26 - Inline Event Handlers and CSP
+**Vulnerability:** An inline `onclick` handler was found in `index.html` which conflicted with the strict `script-src` Content Security Policy (missing `'unsafe-inline'`), rendering the functionality (alert dismissal) broken.
+**Learning:** Strict CSP is effective at blocking inline scripts, but can silently break UI features if they rely on legacy inline handlers. Manual verification or frontend tests are crucial when tightening CSP.
+**Prevention:** Use event delegation in external JavaScript files for all user interactions. Avoid `on*` attributes in HTML.

--- a/app/static/ui.js
+++ b/app/static/ui.js
@@ -90,6 +90,18 @@
         });
     }
 
+    // Manual alert dismissal (replaces inline onclick)
+    function initDismissButtons() {
+        document.addEventListener('click', function(e) {
+            if (e.target.closest('.alert-close')) {
+                const alert = e.target.closest('.alert');
+                if (alert) {
+                    alert.remove();
+                }
+            }
+        });
+    }
+
     // Initialize Copy to Clipboard buttons
     function initCopyButtons() {
         document.addEventListener('click', function(e) {
@@ -128,6 +140,7 @@
     document.addEventListener('DOMContentLoaded', function() {
         initSubmitButtons();
         initAutoDismissAlerts();
+        initDismissButtons();
         initCopyButtons();
     });
 })();

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -49,7 +49,6 @@
                             {{ message }}
                             <button type="button"
                                     class="alert-close"
-                                    onclick="this.parentElement.remove()"
                                     aria-label="Close">×</button>
                         </div>
                     {% endfor %}


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

Refactored the alert dismissal functionality to remove inline JavaScript (`onclick`), which violated the strict Content Security Policy (`script-src`) defined in `app.py`. This change ensures compliance with security best practices and fixes a potential issue where the close button would not function if the CSP was strictly enforced.

**Changes:**
- `app/templates/index.html`: Removed `onclick="this.parentElement.remove()"`.
- `app/static/ui.js`: Added event delegation for `.alert-close` buttons.

**Verification:**
- Verified manually using a Playwright script that the alert is correctly dismissed.
- Passed all existing backend tests.

---
*PR created automatically by Jules for task [18126560932789780418](https://jules.google.com/task/18126560932789780418) started by @billnapier*