### PR TITLE
🎨 Palette: Icon-only Remove buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -37,3 +37,7 @@
 ## 2026-01-21 - Copy to Clipboard
 **Learning:** Users often need to copy IDs (like Calendar IDs) to share or use elsewhere, but selecting and copying text manually is error-prone and tedious. A dedicated copy button significantly reduces friction for these common "utility" actions.
 **Action:** Implemented a reusable `initCopyButtons` function in `ui.js` that enhances any element with `.btn-copy` class. It uses the Clipboard API and provides immediate visual feedback (changing text to "Copied!" and color to green) to confirm the action, handling the interaction lifecycle gracefully.
+
+## 2026-01-29 - Icon-only Buttons for Repetitive Actions
+**Learning:** In lists or grids where every item has the same secondary action (like "Remove"), repeating the text button creates visual clutter and consumes valuable horizontal space.
+**Action:** Replaced "Remove" text buttons with a standardized `.btn-icon` class and a trash icon. This improves the signal-to-noise ratio and works better on mobile. Always ensure icon-only buttons have an `aria-label` and `title` for accessibility and clarity.

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -276,6 +276,22 @@ footer {
     font-size: 0.85rem;
 }
 
+.btn-icon {
+    padding: 0.5rem;
+    line-height: 0;
+    width: 2.25rem;
+    height: 2.25rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;
+}
+
+.btn-icon svg {
+    width: 1.2em;
+    height: 1.2em;
+}
+
 .btn-copy-success {
     background-color: var(--success-color);
     color: white;

--- a/app/templates/create_sync.html
+++ b/app/templates/create_sync.html
@@ -142,7 +142,12 @@
                                 <!-- Actions -->
                                 <div class="source-actions">
                                     <span class="field-label visibility-hidden">Remove</span>
-                                    <button type="button" class="btn btn-danger" aria-label="Remove Source">Remove</button>
+                                    <button type="button" class="btn btn-danger btn-icon" aria-label="Remove Source" title="Remove Source">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                                            <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/>
+                                            <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/>
+                                        </svg>
+                                    </button>
                                 </div>
                             </div>
                         </div>
@@ -199,7 +204,12 @@
                 </label>
                 <div class="source-actions">
                     <span class="field-label visibility-hidden">Remove</span>
-                    <button type="button" class="btn btn-danger" aria-label="Remove Source">Remove</button>
+                    <button type="button" class="btn btn-danger btn-icon" aria-label="Remove Source" title="Remove Source">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                            <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/>
+                            <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/>
+                        </svg>
+                    </button>
                 </div>
             </div>
         </template>

--- a/app/templates/edit_sync.html
+++ b/app/templates/edit_sync.html
@@ -153,7 +153,12 @@
                                     <!-- Actions -->
                                     <div class="source-actions">
                                         <span class="field-label visibility-hidden">Remove</span>
-                                        <button type="button" class="btn btn-danger" aria-label="Remove Source">Remove</button>
+                                        <button type="button" class="btn btn-danger btn-icon" aria-label="Remove Source" title="Remove Source">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                                                <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/>
+                                                <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/>
+                                            </svg>
+                                        </button>
                                     </div>
                                 </div>
                             {% endfor %}
@@ -198,7 +203,12 @@
                                     </label>
                                     <div class="source-actions">
                                         <span class="field-label visibility-hidden">Remove</span>
-                                        <button type="button" class="btn btn-danger" aria-label="Remove Source">Remove</button>
+                                        <button type="button" class="btn btn-danger btn-icon" aria-label="Remove Source" title="Remove Source">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                                                <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/>
+                                                <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/>
+                                            </svg>
+                                        </button>
                                     </div>
                                 </div>
                             {% endif %}
@@ -269,7 +279,12 @@
                 </label>
                 <div class="source-actions">
                     <span class="field-label visibility-hidden">Remove</span>
-                    <button type="button" class="btn btn-danger" aria-label="Remove Source">Remove</button>
+                    <button type="button" class="btn btn-danger btn-icon" aria-label="Remove Source" title="Remove Source">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                            <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/>
+                            <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/>
+                        </svg>
+                    </button>
                 </div>
             </div>
         </template>


### PR DESCRIPTION
💡 What: Replaced text-based "Remove" buttons with icon-only trash buttons in the Source Calendars list.
🎯 Why: To reduce visual clutter and save horizontal space in the form, especially on mobile devices.
📸 Before/After: Replaced "Remove" text with a red trash icon.
♿ Accessibility: Preserved `aria-label` and added `title` for tooltip support.

---
*PR created automatically by Jules for task [2149617706184082755](https://jules.google.com/task/2149617706184082755) started by @billnapier*