### PR TITLE
🎨 Palette: Use icon button for source removal

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -37,3 +37,7 @@
 ## 2026-01-21 - Copy to Clipboard
 **Learning:** Users often need to copy IDs (like Calendar IDs) to share or use elsewhere, but selecting and copying text manually is error-prone and tedious. A dedicated copy button significantly reduces friction for these common "utility" actions.
 **Action:** Implemented a reusable `initCopyButtons` function in `ui.js` that enhances any element with `.btn-copy` class. It uses the Clipboard API and provides immediate visual feedback (changing text to "Copied!" and color to green) to confirm the action, handling the interaction lifecycle gracefully.
+
+## 2026-02-12 - Icon-Only Buttons
+**Learning:** Text buttons (like "Remove") in repeated list items consume excessive horizontal space and visual weight, cluttering the UI. Standardizing on icon-only buttons for repeated secondary actions (like deletion) improves scanability and aesthetics, provided they remain accessible.
+**Action:** Introduced a reusable `.btn-icon` class for square, centered icon buttons. Replaced "Remove" text buttons with SVG Trash icons in the source list. Crucially, maintained accessibility by ensuring `aria-label` and `title` attributes are present to describe the action to screen readers and tooltips.

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -293,6 +293,17 @@ footer {
     font-weight: normal;
 }
 
+.btn-icon {
+    padding: 0;
+    width: 38px;
+    height: 38px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;
+    flex-shrink: 0;
+}
+
 /* Form & Card Styles */
 .form-card {
     background: var(--white);

--- a/app/static/sync_form.js
+++ b/app/static/sync_form.js
@@ -12,7 +12,7 @@
     function updateRemoveButtons() {
         const entries = document.querySelectorAll('.ical-entry');
         entries.forEach((entry) => {
-            const btn = entry.querySelector('.btn-danger'); // Remove button
+            const btn = entry.querySelector('.btn-remove'); // Remove button
             if (!btn) return;
 
             if (entries.length === 1) {
@@ -110,8 +110,8 @@
         if (container) {
             container.addEventListener('click', function(e) {
                 // Handle Remove Button
-                // We check for .btn-danger or closest .btn-danger
-                const removeBtn = e.target.closest('.btn-danger');
+                // We check for .btn-remove or closest .btn-remove
+                const removeBtn = e.target.closest('.btn-remove');
                 if (removeBtn && container.contains(removeBtn)) {
                     removeSourceEntry(removeBtn);
                 }

--- a/app/templates/create_sync.html
+++ b/app/templates/create_sync.html
@@ -142,7 +142,12 @@
                                 <!-- Actions -->
                                 <div class="source-actions">
                                     <span class="field-label visibility-hidden">Remove</span>
-                                    <button type="button" class="btn btn-danger" aria-label="Remove Source">Remove</button>
+                                    <button type="button" class="btn btn-outline-danger btn-icon btn-remove" aria-label="Remove Source" title="Remove Source">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                                            <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
+                                            <path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
+                                        </svg>
+                                    </button>
                                 </div>
                             </div>
                         </div>
@@ -199,7 +204,12 @@
                 </label>
                 <div class="source-actions">
                     <span class="field-label visibility-hidden">Remove</span>
-                    <button type="button" class="btn btn-danger" aria-label="Remove Source">Remove</button>
+                    <button type="button" class="btn btn-outline-danger btn-icon btn-remove" aria-label="Remove Source" title="Remove Source">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                            <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
+                            <path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
+                        </svg>
+                    </button>
                 </div>
             </div>
         </template>

--- a/app/templates/edit_sync.html
+++ b/app/templates/edit_sync.html
@@ -153,7 +153,12 @@
                                     <!-- Actions -->
                                     <div class="source-actions">
                                         <span class="field-label visibility-hidden">Remove</span>
-                                        <button type="button" class="btn btn-danger" aria-label="Remove Source">Remove</button>
+                                        <button type="button" class="btn btn-outline-danger btn-icon btn-remove" aria-label="Remove Source" title="Remove Source">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                                                <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
+                                                <path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
+                                            </svg>
+                                        </button>
                                     </div>
                                 </div>
                             {% endfor %}
@@ -198,7 +203,12 @@
                                     </label>
                                     <div class="source-actions">
                                         <span class="field-label visibility-hidden">Remove</span>
-                                        <button type="button" class="btn btn-danger" aria-label="Remove Source">Remove</button>
+                                        <button type="button" class="btn btn-outline-danger btn-icon btn-remove" aria-label="Remove Source" title="Remove Source">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                                                <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
+                                                <path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
+                                            </svg>
+                                        </button>
                                     </div>
                                 </div>
                             {% endif %}
@@ -269,7 +279,12 @@
                 </label>
                 <div class="source-actions">
                     <span class="field-label visibility-hidden">Remove</span>
-                    <button type="button" class="btn btn-danger" aria-label="Remove Source">Remove</button>
+                    <button type="button" class="btn btn-outline-danger btn-icon btn-remove" aria-label="Remove Source" title="Remove Source">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                            <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
+                            <path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
+                        </svg>
+                    </button>
                 </div>
             </div>
         </template>

--- a/tests/test_ui_buttons.py
+++ b/tests/test_ui_buttons.py
@@ -1,0 +1,43 @@
+import sys
+import os
+from unittest.mock import MagicMock, patch
+import pytest
+
+# Add the app directory to the path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../")))
+
+from app.app import app as flask_app
+
+@pytest.fixture
+def client():
+    flask_app.config["TESTING"] = True
+    flask_app.secret_key = "test_secret"
+    with flask_app.test_client() as test_client:
+        yield test_client
+
+def test_create_sync_remove_button_ux(client):
+    """Test that the create sync page renders the remove button with correct UX attributes."""
+
+    # Mock firestore and fetch_user_calendars
+    with patch("app.main.routes.firestore") as mock_fs, \
+         patch("app.main.routes.fetch_user_calendars", return_value=[]):
+
+        # Mock session to simulate logged in user
+        with client.session_transaction() as sess:
+            sess["user"] = {"uid": "test_uid", "name": "Test User"}
+
+        resp = client.get("/create_sync")
+        assert resp.status_code == 200
+        html = resp.data.decode("utf-8")
+
+        # Verify attributes for accessibility and UX
+        # We expect to find the new class 'btn-icon' and 'btn-remove' eventually
+        # But for now, we just check if we can find the button.
+        # This test is expected to FAIL on specific class checks until I implement them.
+
+        # We want to check for the new classes and aria-label
+        assert 'aria-label="Remove Source"' in html
+        assert 'title="Remove Source"' in html
+        assert 'btn-icon' in html
+        assert 'btn-remove' in html
+        assert '<svg' in html  # Ensure we have an SVG icon


### PR DESCRIPTION
This PR replaces the "Remove" text button in the source calendar list with a cleaner, space-saving icon button (Trash icon).
It improves the visual clutter of the form, especially when multiple sources are added.
Accessibility is maintained via `aria-label` and `title` attributes.
Functionality is decoupled from the `.btn-danger` class by introducing a `.btn-remove` class.


---
*PR created automatically by Jules for task [14461519578602255603](https://jules.google.com/task/14461519578602255603) started by @billnapier*