### PR TITLE
⚡ Bolt: Optimize sync creation latency by skipping redundant I/O

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -163,8 +163,8 @@ def _handle_edit_sync_post(req, sync_ref, calendars):
                 destination_summary = cal["summary"]
                 break
 
-    # Re-fetch source names
-    source_names = resolve_source_names(sources, calendars)
+    # Optimization: Resolve names from local cache only (skip remote fetch)
+    source_names = resolve_source_names(sources, calendars, fetch_remote=False)
 
     sync_ref.update(
         {
@@ -360,7 +360,9 @@ def _handle_create_sync_post(user):
         }
     )
 
-    source_names = resolve_source_names(sources, user_calendars)
+    # Optimization: Resolve names from local cache only (skip remote fetch)
+    # to keep UI responsive. Remote fetch happens during sync.
+    source_names = resolve_source_names(sources, user_calendars, fetch_remote=False)
     new_sync_ref.update({"source_names": source_names})
 
     # Auto-sync immediately after creation


### PR DESCRIPTION
Identified that `resolve_source_names` was performing network requests to fetch iCal titles during the synchronous "Create Sync" and "Edit Sync" POST requests. This was redundant because `sync_calendar_logic`, which runs immediately after, also fetches the same content.

Optimization:
1.  Modified `resolve_source_names` in `app/sync/logic.py` to allow skipping remote fetches via `fetch_remote=False`.
2.  Updated `app/main/routes.py` to use this flag during creation and editing.

Impact:
- Reduces external network requests by N (where N is number of iCal sources) during the POST request.
- Improves perceived performance/responsiveness of the form submission.
- Maintains data consistency for Google sources (resolved from memory) and relies on the subsequent sync to populate iCal names.

---
*PR created automatically by Jules for task [12989740896746907999](https://jules.google.com/task/12989740896746907999) started by @billnapier*