### PR TITLE
🎨 Palette: Use icon-only buttons for remove action

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -37,3 +37,7 @@
 ## 2026-01-21 - Copy to Clipboard
 **Learning:** Users often need to copy IDs (like Calendar IDs) to share or use elsewhere, but selecting and copying text manually is error-prone and tedious. A dedicated copy button significantly reduces friction for these common "utility" actions.
 **Action:** Implemented a reusable `initCopyButtons` function in `ui.js` that enhances any element with `.btn-copy` class. It uses the Clipboard API and provides immediate visual feedback (changing text to "Copied!" and color to green) to confirm the action, handling the interaction lifecycle gracefully.
+
+## 2026-01-31 - Icon-Only Action Buttons
+**Learning:** In list interfaces (like source lists), repeating text buttons like "Remove" creates visual clutter and consumes valuable horizontal space, especially on desktop. Icon-only buttons (with tooltips) are cleaner and recognizable.
+**Action:** Introduced a reusable `.btn-icon` class in `style.css` for circular, centered icon buttons. Replaced the text-based "Remove" button with a Trash icon button in sync forms. Also decoupled the JS logic from the visual style by targeting `.btn-remove` instead of `.btn-danger`, allowing for flexible styling updates without breaking behavior.

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -928,3 +928,21 @@ details[open] summary.help-summary::before {
         transform: rotate(360deg);
     }
 }
+
+/* Icon Buttons */
+.btn-icon {
+    padding: 0.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    line-height: 0;
+}
+
+.btn-icon svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    fill: currentcolor;
+}

--- a/app/static/sync_form.js
+++ b/app/static/sync_form.js
@@ -12,7 +12,7 @@
     function updateRemoveButtons() {
         const entries = document.querySelectorAll('.ical-entry');
         entries.forEach((entry) => {
-            const btn = entry.querySelector('.btn-danger'); // Remove button
+            const btn = entry.querySelector('.btn-remove'); // Remove button
             if (!btn) return;
 
             if (entries.length === 1) {
@@ -110,8 +110,8 @@
         if (container) {
             container.addEventListener('click', function(e) {
                 // Handle Remove Button
-                // We check for .btn-danger or closest .btn-danger
-                const removeBtn = e.target.closest('.btn-danger');
+                // We check for .btn-remove or closest .btn-remove
+                const removeBtn = e.target.closest('.btn-remove');
                 if (removeBtn && container.contains(removeBtn)) {
                     removeSourceEntry(removeBtn);
                 }

--- a/app/templates/create_sync.html
+++ b/app/templates/create_sync.html
@@ -142,7 +142,11 @@
                                 <!-- Actions -->
                                 <div class="source-actions">
                                     <span class="field-label visibility-hidden">Remove</span>
-                                    <button type="button" class="btn btn-danger" aria-label="Remove Source">Remove</button>
+                                    <button type="button" class="btn btn-danger btn-icon btn-remove" aria-label="Remove Source" title="Remove Source">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                                            <path fill-rule="evenodd" d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z" clip-rule="evenodd" />
+                                        </svg>
+                                    </button>
                                 </div>
                             </div>
                         </div>
@@ -199,7 +203,11 @@
                 </label>
                 <div class="source-actions">
                     <span class="field-label visibility-hidden">Remove</span>
-                    <button type="button" class="btn btn-danger" aria-label="Remove Source">Remove</button>
+                    <button type="button" class="btn btn-danger btn-icon btn-remove" aria-label="Remove Source" title="Remove Source">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                            <path fill-rule="evenodd" d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z" clip-rule="evenodd" />
+                        </svg>
+                    </button>
                 </div>
             </div>
         </template>

--- a/app/templates/edit_sync.html
+++ b/app/templates/edit_sync.html
@@ -153,7 +153,11 @@
                                     <!-- Actions -->
                                     <div class="source-actions">
                                         <span class="field-label visibility-hidden">Remove</span>
-                                        <button type="button" class="btn btn-danger" aria-label="Remove Source">Remove</button>
+                                        <button type="button" class="btn btn-danger btn-icon btn-remove" aria-label="Remove Source" title="Remove Source">
+                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                                                <path fill-rule="evenodd" d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z" clip-rule="evenodd" />
+                                            </svg>
+                                        </button>
                                     </div>
                                 </div>
                             {% endfor %}
@@ -198,7 +202,11 @@
                                     </label>
                                     <div class="source-actions">
                                         <span class="field-label visibility-hidden">Remove</span>
-                                        <button type="button" class="btn btn-danger" aria-label="Remove Source">Remove</button>
+                                        <button type="button" class="btn btn-danger btn-icon btn-remove" aria-label="Remove Source" title="Remove Source">
+                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                                                <path fill-rule="evenodd" d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z" clip-rule="evenodd" />
+                                            </svg>
+                                        </button>
                                     </div>
                                 </div>
                             {% endif %}
@@ -269,7 +277,11 @@
                 </label>
                 <div class="source-actions">
                     <span class="field-label visibility-hidden">Remove</span>
-                    <button type="button" class="btn btn-danger" aria-label="Remove Source">Remove</button>
+                    <button type="button" class="btn btn-danger btn-icon btn-remove" aria-label="Remove Source" title="Remove Source">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                            <path fill-rule="evenodd" d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z" clip-rule="evenodd" />
+                        </svg>
+                    </button>
                 </div>
             </div>
         </template>


### PR DESCRIPTION
🎨 **UX Improvement: Icon-Only Remove Buttons**

💡 **What:** Replaced the text-based "Remove" button in the source list with a circular Trash icon button.

🎯 **Why:** 
- Reduces visual clutter in repeated list items.
- Saves horizontal space, especially on desktop.
- Aligns with modern UI patterns for list actions.

♿ **Accessibility:**
- Added `aria-label="Remove Source"` and `title` tooltip to ensure the button remains accessible and understandable.
- Maintained focus states.

📸 **Verification:**
- Verified using Playwright script to ensure visibility, correct classes, and functional logic (add/remove).
- Linted CSS to ensure compliance.


---
*PR created automatically by Jules for task [1305358426490263061](https://jules.google.com/task/1305358426490263061) started by @billnapier*