### PR TITLE
Fix XSRF error when editing sync setting

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -241,9 +241,6 @@ def edit_sync(sync_id):
     if not user:
         return redirect(url_for("auth.login"))
 
-    if not verify_csrf_token(request.form.get("csrf_token")):
-        return "Invalid CSRF token", 403
-
     db = firestore.client()
     sync_ref = db.collection("syncs").document(sync_id)
     sync_doc = sync_ref.get()


### PR DESCRIPTION
Fixes an invalid CSRF verification token check that executed on `GET` requests in `/edit_sync/<sync_id>` endpoint and returned 403 Invalid CSRF token. The `POST` request block in the same route properly checks for the CSRF token.