### PR TITLE
Fix edit sync save changes button

### DIFF
--- a/app/static/ui.js
+++ b/app/static/ui.js
@@ -53,7 +53,9 @@
                 submitBtn.appendChild(spinner);
                 submitBtn.appendChild(document.createTextNode(' ' + loadingText));
 
-                submitBtn.disabled = true;
+                setTimeout(() => {
+                    submitBtn.disabled = true;
+                }, 0);
                 submitBtn.classList.add('btn-loading');
             });
         });

--- a/app/static/ui.js
+++ b/app/static/ui.js
@@ -53,6 +53,8 @@
                 submitBtn.appendChild(spinner);
                 submitBtn.appendChild(document.createTextNode(' ' + loadingText));
 
+                // Defer disabling to prevent a race condition in WebKit browsers where
+                // synchronous disabling can cancel the form submission.
                 setTimeout(() => {
                     submitBtn.disabled = true;
                 }, 0);

--- a/app/templates/create_sync.html
+++ b/app/templates/create_sync.html
@@ -58,13 +58,13 @@
                                 <option value="" disabled selected>Select a calendar</option>
                                 {% for cal in calendars %}
                                     <option value="{{ cal.id }}"
-                                            {% if cal.summary=='Family' %}selected{% endif %}>{{ cal.summary }}</option>
+                                            {% if cal.summary == 'Family' %}selected{% endif %}>{{ cal.summary }}</option>
                                 {% endfor %}
                             </select>
                         {% else %}
                             <!-- Fallback if no calendars found or error -->
                             <input type="text"
-                                   id="destination_calendar_id"
+                                   id="destination_calendar_id_manual"
                                    name="destination_calendar_id"
                                    placeholder="e.g., primary or calendar_id@group.calendar.google.com"
                                    required

--- a/app/templates/edit_sync.html
+++ b/app/templates/edit_sync.html
@@ -57,7 +57,7 @@
                                 <option value="" disabled>Select a calendar</option>
                                 {% for cal in calendars %}
                                     <option value="{{ cal.id }}"
-                                            {% if cal.id==sync.destination_calendar_id %}selected{% endif %}>
+                                            {% if cal.id == sync.destination_calendar_id %}selected{% endif %}>
                                         {{
                                         cal.summary }}
                                     </option>
@@ -65,7 +65,7 @@
                             </select>
                         {% else %}
                             <input type="text"
-                                   id="destination_calendar_id"
+                                   id="destination_calendar_id_manual"
                                    name="destination_calendar_id"
                                    value="{{ sync.destination_calendar_id }}"
                                    required>
@@ -103,8 +103,8 @@
                                         <span class="field-label">Type</span>
                                         <select>
                                             <option value="ical"
-                                                    {% if (source.type or 'ical' )=='ical' %}selected{% endif %}>iCal URL</option>
-                                            <option value="google" {% if source.type=='google' %}selected{% endif %}>Google Cal</option>
+                                                    {% if (source.type or 'ical' ) == 'ical' %}selected{% endif %}>iCal URL</option>
+                                            <option value="google" {% if source.type == 'google' %}selected{% endif %}>Google Cal</option>
                                         </select>
                                     </label>
                                     <!-- Source Input (Google/URL) -->
@@ -120,7 +120,7 @@
                                                         Calendar
                                                     </option>
                                                     {% for cal in calendars %}
-                                                        <option value="{{ cal.id }}" {% if cal.id==source.id %}selected{% endif %}>
+                                                        <option value="{{ cal.id }}" {% if cal.id == source.id %}selected{% endif %}>
                                                             {{
                                                             cal.summary }}
                                                         </option>
@@ -135,7 +135,9 @@
                                                     {% if (source.type or 'ical') != 'ical' %}hidden{% endif %}">
                                             <input type="url"
                                                    name="source_urls"
-                                                   value="{% if source.type != 'google' %}{{ source.url }}{% endif %}"
+                                                   value="{% if source.type != 'google' %}
+                                                              {{ source.url }}
+                                                          {% endif %}"
                                                    placeholder="https://example.com/calendar.ics"
                                                    aria-label="Source Calendar URL"
                                                    inputmode="url">

--- a/app/templates/edit_sync.html
+++ b/app/templates/edit_sync.html
@@ -135,7 +135,7 @@
                                                     {% if (source.type or 'ical') != 'ical' %}hidden{% endif %}">
                                             <input type="url"
                                                    name="source_urls"
-                                                   value="{{ source.url }}"
+                                                   value="{% if source.type != 'google' %}{{ source.url }}{% endif %}"
                                                    placeholder="https://example.com/calendar.ics"
                                                    aria-label="Source Calendar URL"
                                                    inputmode="url">


### PR DESCRIPTION
This PR fixes a bug where the edit sync save changes button fails silently without network traffic.

The issue was that an invisible HTML5 input element with `type="url"` was receiving a Google Calendar ID as a value upon form rendering, causing native browser CSS/validation to abort submission. In addition, the JS was updated to use `setTimeout(..., 0)` to disable buttons to prevent execution races in WebKit based browsers.

Tested locally with `pytest`.