### PR TITLE
Fix unstable UIDs by auto-detecting and generating stable hashes

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -196,7 +196,14 @@ def _get_sources_from_form(form):
                     # Validate URL to prevent invalid data and SSRF at configuration time
                     validate_url(url)
                     unstable_uid = check_unstable_uid(url)
-                    sources.append({"type": "ical", "url": url, "prefix": prefix, "unstable_uid": unstable_uid})
+                    sources.append(
+                        {
+                            "type": "ical",
+                            "url": url,
+                            "prefix": prefix,
+                            "unstable_uid": unstable_uid,
+                        }
+                    )
 
     return sources
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -19,7 +19,12 @@ import google.api_core.exceptions
 from google.cloud import tasks_v2
 
 from app.utils import get_client_config, generate_csrf_token, verify_csrf_token
-from app.sync import sync_calendar_logic, fetch_user_calendars, resolve_source_names
+from app.sync import (
+    sync_calendar_logic,
+    fetch_user_calendars,
+    resolve_source_names,
+    check_unstable_uid,
+)
 from app.security import verify_task_auth, validate_url
 
 from . import main_bp
@@ -190,7 +195,8 @@ def _get_sources_from_form(form):
                 if url:
                     # Validate URL to prevent invalid data and SSRF at configuration time
                     validate_url(url)
-                    sources.append({"type": "ical", "url": url, "prefix": prefix})
+                    unstable_uid = check_unstable_uid(url)
+                    sources.append({"type": "ical", "url": url, "prefix": prefix, "unstable_uid": unstable_uid})
 
     return sources
 

--- a/app/sync/__init__.py
+++ b/app/sync/__init__.py
@@ -2,4 +2,5 @@ from app.sync.logic import (
     sync_calendar_logic,
     fetch_user_calendars,
     resolve_source_names,
+    check_unstable_uid,
 )

--- a/app/sync/logic.py
+++ b/app/sync/logic.py
@@ -129,6 +129,7 @@ def check_unstable_uid(url):
     Streams the response briefly to extract the first VEVENT's UID.
     Fetches up to 3 times to compare. Returns True if UIDs differ.
     """
+
     def get_first_uid():
         try:
             with contextlib.closing(
@@ -149,24 +150,28 @@ def check_unstable_uid(url):
                             in_event = False
                 return None
         except Exception as e:
-            logger.warning("Error fetching UID for stability check from %s: %s", clean_url_for_log(url), e)
+            logger.warning(
+                "Error fetching UID for stability check from %s: %s",
+                clean_url_for_log(url),
+                e,
+            )
             return None
 
     uid1 = get_first_uid()
     if not uid1:
         return False
-    
+
     uid2 = get_first_uid()
     if not uid2:
         return False
-        
+
     if uid1 != uid2:
         return True
-        
+
     uid3 = get_first_uid()
     if not uid3:
         return False
-        
+
     return uid1 != uid3
 
 
@@ -587,10 +592,10 @@ def _fetch_source_events(
             for component in components:
                 all_events_items.append(
                     {
-                        "component": component, 
-                        "prefix": prefix, 
+                        "component": component,
+                        "prefix": prefix,
                         "source_title": name,
-                        "unstable_uid": source.get("unstable_uid", False)
+                        "unstable_uid": source.get("unstable_uid", False),
                     }
                 )
 
@@ -750,7 +755,9 @@ def _get_existing_events_map(
     return existing_map
 
 
-def _build_event_body(event, prefix, source_title=None, base_url=None, unstable_uid=False):
+def _build_event_body(
+    event, prefix, source_title=None, base_url=None, unstable_uid=False
+):
     """
     Helper to construct Google Calendar event body.
     """
@@ -775,17 +782,20 @@ def _build_event_body(event, prefix, source_title=None, base_url=None, unstable_
     summary = str(event.get("SUMMARY", ""))
     if prefix:
         summary = f"[{prefix}] {summary}"
-        
+
     # If the feed generates random UIDs (like BenchApp), we must generate a stable ID
     if unstable_uid:
         import hashlib
+
         event_url = event.get("URL")
         if event_url:
             stable_string = f"url:{str(event_url)}"
         else:
-            stable_string = f"fallback:{summary}:{start.get('dateTime', start.get('date', ''))}"
-            
-        uid = hashlib.sha256(stable_string.encode('utf-8')).hexdigest()
+            stable_string = (
+                f"fallback:{summary}:{start.get('dateTime', start.get('date', ''))}"
+            )
+
+        uid = hashlib.sha256(stable_string.encode("utf-8")).hexdigest()
 
     body = {
         "summary": summary,

--- a/app/sync/logic.py
+++ b/app/sync/logic.py
@@ -932,6 +932,7 @@ def _batch_upsert_events(
             item["prefix"],
             item.get("source_title"),
             base_url=base_url,
+            unstable_uid=item.get("unstable_uid", False),
         )
         if not body:
             continue

--- a/app/sync/logic.py
+++ b/app/sync/logic.py
@@ -780,8 +780,6 @@ def _build_event_body(
         return None, None
 
     summary = str(event.get("SUMMARY", ""))
-    if prefix:
-        summary = f"[{prefix}] {summary}"
 
     # If the feed generates random UIDs (like BenchApp), we must generate a stable ID
     if unstable_uid:
@@ -791,11 +789,15 @@ def _build_event_body(
         if event_url:
             stable_string = f"url:{str(event_url)}"
         else:
+            # Use the raw summary (without prefix) for stability if the prefix is changed later
             stable_string = (
                 f"fallback:{summary}:{start.get('dateTime', start.get('date', ''))}"
             )
 
         uid = hashlib.sha256(stable_string.encode("utf-8")).hexdigest()
+
+    if prefix:
+        summary = f"[{prefix}] {summary}"
 
     body = {
         "summary": summary,

--- a/app/sync/logic.py
+++ b/app/sync/logic.py
@@ -123,6 +123,53 @@ def get_calendar_name_from_ical(url):
     return url
 
 
+def check_unstable_uid(url):
+    """
+    Checks if an ICS feed generates unstable (random) UIDs across requests.
+    Streams the response briefly to extract the first VEVENT's UID.
+    Fetches up to 3 times to compare. Returns True if UIDs differ.
+    """
+    def get_first_uid():
+        try:
+            with contextlib.closing(
+                safe_requests_get(url, timeout=10, stream=True)
+            ) as response:
+                response.raise_for_status()
+                in_event = False
+                for line in response.iter_lines(decode_unicode=True):
+                    if line:
+                        line_upper = line.upper()
+                        if line_upper.startswith("BEGIN:VEVENT"):
+                            in_event = True
+                        elif in_event and line_upper.startswith("UID:"):
+                            parts = line.split(":", 1)
+                            if len(parts) == 2:
+                                return parts[1].strip()
+                        elif line_upper.startswith("END:VEVENT"):
+                            in_event = False
+                return None
+        except Exception as e:
+            logger.warning("Error fetching UID for stability check from %s: %s", clean_url_for_log(url), e)
+            return None
+
+    uid1 = get_first_uid()
+    if not uid1:
+        return False
+    
+    uid2 = get_first_uid()
+    if not uid2:
+        return False
+        
+    if uid1 != uid2:
+        return True
+        
+    uid3 = get_first_uid()
+    if not uid3:
+        return False
+        
+    return uid1 != uid3
+
+
 def resolve_source_names(sources, calendars, fetch_remote=True):
     """
     Efficiently resolve friendly names for sources.
@@ -539,7 +586,12 @@ def _fetch_source_events(
 
             for component in components:
                 all_events_items.append(
-                    {"component": component, "prefix": prefix, "source_title": name}
+                    {
+                        "component": component, 
+                        "prefix": prefix, 
+                        "source_title": name,
+                        "unstable_uid": source.get("unstable_uid", False)
+                    }
                 )
 
     return all_events_items, source_names
@@ -698,7 +750,7 @@ def _get_existing_events_map(
     return existing_map
 
 
-def _build_event_body(event, prefix, source_title=None, base_url=None):
+def _build_event_body(event, prefix, source_title=None, base_url=None, unstable_uid=False):
     """
     Helper to construct Google Calendar event body.
     """
@@ -723,6 +775,17 @@ def _build_event_body(event, prefix, source_title=None, base_url=None):
     summary = str(event.get("SUMMARY", ""))
     if prefix:
         summary = f"[{prefix}] {summary}"
+        
+    # If the feed generates random UIDs (like BenchApp), we must generate a stable ID
+    if unstable_uid:
+        import hashlib
+        event_url = event.get("URL")
+        if event_url:
+            stable_string = f"url:{str(event_url)}"
+        else:
+            stable_string = f"fallback:{summary}:{start.get('dateTime', start.get('date', ''))}"
+            
+        uid = hashlib.sha256(stable_string.encode('utf-8')).hexdigest()
 
     body = {
         "summary": summary,
@@ -760,6 +823,7 @@ def _upsert_batch_chunk(
             item["prefix"],
             item.get("source_title"),
             base_url=base_url,
+            unstable_uid=item.get("unstable_uid", False),
         )
         if not body:
             continue


### PR DESCRIPTION
This PR fixes an issue where calendar events from certain ICS feeds (like BenchApp) are duplicated on every sync because they generate random UIDs per request.

Changes:
- Adds a helper `check_unstable_uid(url)` to fetch the URL briefly multiple times to check if the generated UID is stable.
- Invokes this helper in `_get_sources_from_form` when configuring ical sources and saves an `unstable_uid` flag to Firestore.
- In `_build_event_body`, if `unstable_uid` is True, we fallback to generating a stable SHA256 hash using the event's URL or a combination of SUMMARY and DTSTART.